### PR TITLE
port to Gtk4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,15 +1,19 @@
 name = "GtkSourceWidget"
 uuid = "6ceb4976-07da-5329-b1cb-20978726f1f4"
-version = "1.0.1"
+version = "2.0.0"
 
 [deps]
-Gtk = "4c0ca9eb-093a-5379-98c5-f87ac0bbbf44"
+Gtk4 = "9db2cae5-386f-4011-9d63-a5602296539b"
 GtkSourceView_jll = "bf9c6edb-e643-5064-a5c3-0f96a1285812"
+BitFlags = "d1d4a3ce-64b1-5f1a-9ba4-7e7e69966f35"
+CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
 
 [compat]
-Gtk = "1"
-GtkSourceView_jll = "4.4.0"
-julia = "1.3"
+BitFlags = "0.1.5"
+CEnum = "0.4, 0.5"
+Gtk4 = "0.6"
+GtkSourceView_jll = "5.1.0"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/examples/simple.jl
+++ b/examples/simple.jl
@@ -1,0 +1,13 @@
+using GtkSourceWidget, Gtk4
+
+win=GtkWindow("test",400,400)
+sv = GtkSourceView()
+win[] = sv
+
+buff = sv.buffer
+langman = GtkSourceLanguageManager()
+lang = GtkSourceWidget.language(langman,"julia")
+buff.text = open("simple.jl","r") do f
+    read(f,String)
+end
+GtkSourceWidget.G_.set_language(buff,lang)

--- a/gen/gen.jl
+++ b/gen/gen.jl
@@ -1,0 +1,68 @@
+using GI
+GI.prepend_search_path("/usr/lib64/girepository-1.0")
+GI.prepend_search_path("/usr/local/lib64/girepository-1.0")
+
+toplevel, exprs, exports = GI.output_exprs()
+
+path="../src/gen"
+
+ns = GINamespace(:GtkSource,"5")
+
+## constants, enums, and flags
+
+const_mod = Expr(:block)
+
+const_exports = Expr(:export)
+
+c = GI.all_const_exprs!(const_mod, const_exports, ns; skiplist= [])
+push!(const_mod.args, const_exports)
+
+push!(exprs, const_mod)
+
+## export constants, enums, and flags code
+GI.write_to_file(path,"gtksourceview_consts",toplevel)
+
+## structs and objects
+
+toplevel, exprs, exports = GI.output_exprs()
+GI.struct_cache_expr!(exprs)
+GI.all_interfaces!(exprs,exports,ns;skiplist=[])
+GI.all_objects!(exprs,exports,ns,skiplist=[],constructor_skiplist=[])
+
+disguised = []
+special = []
+struct_skiplist=vcat(disguised, special, [])
+
+struct_skiplist = GI.all_struct_exprs!(exprs,exports,ns;excludelist=struct_skiplist)
+GI.all_callbacks!(exprs, exports, ns)
+
+push!(exprs,exports)
+
+GI.write_to_file(path,"gtksourceview_structs",toplevel)
+
+## struct methods
+
+toplevel, exprs, exports = GI.output_exprs()
+
+GI.all_struct_methods!(exprs,ns,struct_skiplist=vcat(struct_skiplist,[]);print_detailed=true)
+
+## object methods
+
+objects=GI.get_all(ns,GI.GIObjectInfo)
+
+object_skiplist=[]
+
+skiplist=[:get_default]
+
+GI.all_object_methods!(exprs,ns;skiplist=skiplist,object_skiplist=object_skiplist,interface_helpers=false)
+GI.all_interface_methods!(exprs,ns;skiplist=[],interface_skiplist=[])
+
+GI.write_to_file(path,"gtksourceview_methods",toplevel)
+
+## functions
+
+toplevel, exprs, exports = GI.output_exprs()
+
+GI.all_functions!(exprs,ns,skiplist=skiplist)
+
+GI.write_to_file(path,"gtksourceview_functions",toplevel)

--- a/src/gen/gtksourceview_consts
+++ b/src/gen/gtksourceview_consts
@@ -1,0 +1,106 @@
+quote
+$(Expr(:toplevel, quote
+    begin
+        const MAJOR_VERSION = 5
+        const MICRO_VERSION = 0
+        const MINOR_VERSION = 10
+        begin
+            @cenum BackgroundPatternType::Int32 BackgroundPatternType_NONE = 0 BackgroundPatternType_GRID = 1
+            (GLib.g_type(::Type{T}) where T <: BackgroundPatternType) = begin
+                    ccall(("gtk_source_background_pattern_type_get_type", libgtksourceview), GType, ())
+                end
+        end
+        begin
+            @cenum BracketMatchType::Int32 BracketMatchType_NONE = 0 BracketMatchType_OUT_OF_RANGE = 1 BracketMatchType_NOT_FOUND = 2 BracketMatchType_FOUND = 3
+            (GLib.g_type(::Type{T}) where T <: BracketMatchType) = begin
+                    ccall(("gtk_source_bracket_match_type_get_type", libgtksourceview), GType, ())
+                end
+        end
+        begin
+            @cenum ChangeCaseType::Int32 ChangeCaseType_LOWER = 0 ChangeCaseType_UPPER = 1 ChangeCaseType_TOGGLE = 2 ChangeCaseType_TITLE = 3
+            (GLib.g_type(::Type{T}) where T <: ChangeCaseType) = begin
+                    ccall(("gtk_source_change_case_type_get_type", libgtksourceview), GType, ())
+                end
+        end
+        begin
+            @cenum CompletionActivation::Int32 CompletionActivation_NONE = 0 CompletionActivation_INTERACTIVE = 1 CompletionActivation_USER_REQUESTED = 2
+            (GLib.g_type(::Type{T}) where T <: CompletionActivation) = begin
+                    ccall(("gtk_source_completion_activation_get_type", libgtksourceview), GType, ())
+                end
+        end
+        begin
+            @cenum CompletionColumn::Int32 CompletionColumn_ICON = 0 CompletionColumn_BEFORE = 1 CompletionColumn_TYPED_TEXT = 2 CompletionColumn_AFTER = 3 CompletionColumn_COMMENT = 4 CompletionColumn_DETAILS = 5
+            (GLib.g_type(::Type{T}) where T <: CompletionColumn) = begin
+                    ccall(("gtk_source_completion_column_get_type", libgtksourceview), GType, ())
+                end
+        end
+        begin
+            @cenum CompressionType::Int32 CompressionType_NONE = 0 CompressionType_GZIP = 1
+            (GLib.g_type(::Type{T}) where T <: CompressionType) = begin
+                    ccall(("gtk_source_compression_type_get_type", libgtksourceview), GType, ())
+                end
+        end
+        begin
+            @cenum FileLoaderError::Int32 FileLoaderError_TOO_BIG = 0 FileLoaderError_ENCODING_AUTO_DETECTION_FAILED = 1 FileLoaderError_CONVERSION_FALLBACK = 2
+            (GLib.g_type(::Type{T}) where T <: FileLoaderError) = begin
+                    ccall(("gtk_source_file_loader_error_get_type", libgtksourceview), GType, ())
+                end
+        end
+        begin
+            @cenum FileSaverError::Int32 FileSaverError_INVALID_CHARS = 0 FileSaverError_EXTERNALLY_MODIFIED = 1
+            (GLib.g_type(::Type{T}) where T <: FileSaverError) = begin
+                    ccall(("gtk_source_file_saver_error_get_type", libgtksourceview), GType, ())
+                end
+        end
+        begin
+            @cenum GutterRendererAlignmentMode::Int32 GutterRendererAlignmentMode_CELL = 0 GutterRendererAlignmentMode_FIRST = 1 GutterRendererAlignmentMode_LAST = 2
+            (GLib.g_type(::Type{T}) where T <: GutterRendererAlignmentMode) = begin
+                    ccall(("gtk_source_gutter_renderer_alignment_mode_get_type", libgtksourceview), GType, ())
+                end
+        end
+        begin
+            @cenum NewlineType::Int32 NewlineType_LF = 0 NewlineType_CR = 1 NewlineType_CR_LF = 2
+            (GLib.g_type(::Type{T}) where T <: NewlineType) = begin
+                    ccall(("gtk_source_newline_type_get_type", libgtksourceview), GType, ())
+                end
+        end
+        begin
+            @cenum SmartHomeEndType::Int32 SmartHomeEndType_DISABLED = 0 SmartHomeEndType_BEFORE = 1 SmartHomeEndType_AFTER = 2 SmartHomeEndType_ALWAYS = 3
+            (GLib.g_type(::Type{T}) where T <: SmartHomeEndType) = begin
+                    ccall(("gtk_source_smart_home_end_type_get_type", libgtksourceview), GType, ())
+                end
+        end
+        begin
+            @cenum ViewGutterPosition::UInt16 ViewGutterPosition_LINES = 0xffe2 ViewGutterPosition_MARKS = 0xffec
+            (GLib.g_type(::Type{T}) where T <: ViewGutterPosition) = begin
+                    ccall(("gtk_source_view_gutter_position_get_type", libgtksourceview), GType, ())
+                end
+        end
+        begin
+            @bitflag FileSaverFlags::UInt32 FileSaverFlags_NONE = 0 FileSaverFlags_IGNORE_INVALID_CHARS = 1 FileSaverFlags_IGNORE_MODIFICATION_TIME = 2 FileSaverFlags_CREATE_BACKUP = 4
+            (GLib.g_type(::Type{T}) where T <: FileSaverFlags) = begin
+                    ccall(("gtk_source_file_saver_flags_get_type", libgtksourceview), GType, ())
+                end
+        end
+        begin
+            @bitflag SortFlags::UInt32 SortFlags_NONE = 0 SortFlags_CASE_SENSITIVE = 1 SortFlags_REVERSE_ORDER = 2 SortFlags_REMOVE_DUPLICATES = 4
+            (GLib.g_type(::Type{T}) where T <: SortFlags) = begin
+                    ccall(("gtk_source_sort_flags_get_type", libgtksourceview), GType, ())
+                end
+        end
+        begin
+            @bitflag SpaceLocationFlags::UInt32 SpaceLocationFlags_NONE = 0 SpaceLocationFlags_LEADING = 1 SpaceLocationFlags_INSIDE_TEXT = 2 SpaceLocationFlags_TRAILING = 4
+            (GLib.g_type(::Type{T}) where T <: SpaceLocationFlags) = begin
+                    ccall(("gtk_source_space_location_flags_get_type", libgtksourceview), GType, ())
+                end
+        end
+        begin
+            @bitflag SpaceTypeFlags::UInt32 SpaceTypeFlags_NONE = 0 SpaceTypeFlags_SPACE = 1 SpaceTypeFlags_TAB = 2 SpaceTypeFlags_NEWLINE = 4 SpaceTypeFlags_NBSP = 8
+            (GLib.g_type(::Type{T}) where T <: SpaceTypeFlags) = begin
+                    ccall(("gtk_source_space_type_flags_get_type", libgtksourceview), GType, ())
+                end
+        end
+        export BackgroundPatternType, BracketMatchType, ChangeCaseType, CompletionActivation, CompletionColumn, CompressionType, FileLoaderError, FileSaverError, GutterRendererAlignmentMode, NewlineType, SmartHomeEndType, ViewGutterPosition, FileSaverFlags, SortFlags, SpaceLocationFlags, SpaceTypeFlags
+    end
+end))
+end

--- a/src/gen/gtksourceview_functions
+++ b/src/gen/gtksourceview_functions
@@ -1,0 +1,84 @@
+quote
+$(Expr(:toplevel, quote
+    function check_version(_major::Integer, _minor::Integer, _micro::Integer)
+        ret = ccall(("gtk_source_check_version", libgtksourceview), Cint, (UInt32, UInt32, UInt32), _major, _minor, _micro)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function encoding_get_all()
+        ret = ccall(("gtk_source_encoding_get_all", libgtksourceview), Ptr{GLib._GSList{GtkSourceEncoding}}, ())
+        ret2 = GLib.GList(ret, false)
+        ret2
+    end
+    function encoding_get_current()
+        ret = ccall(("gtk_source_encoding_get_current", libgtksourceview), Ptr{GtkSourceEncoding}, ())
+        ret2 = convert(GtkSourceEncoding, ret, false)
+        ret2
+    end
+    function encoding_get_default_candidates()
+        ret = ccall(("gtk_source_encoding_get_default_candidates", libgtksourceview), Ptr{GLib._GSList{GtkSourceEncoding}}, ())
+        ret2 = GLib.GList(ret, false)
+        ret2
+    end
+    function encoding_get_from_charset(_charset::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_encoding_get_from_charset", libgtksourceview), Ptr{GtkSourceEncoding}, (Cstring,), _charset)
+        ret2 = convert_if_not_null(GtkSourceEncoding, ret, false)
+        ret2
+    end
+    function encoding_get_utf8()
+        ret = ccall(("gtk_source_encoding_get_utf8", libgtksourceview), Ptr{GtkSourceEncoding}, ())
+        ret2 = convert(GtkSourceEncoding, ret, false)
+        ret2
+    end
+    function file_loader_error_quark()
+        ret = ccall(("gtk_source_file_loader_error_quark", libgtksourceview), UInt32, ())
+        ret
+    end
+    function file_saver_error_quark()
+        ret = ccall(("gtk_source_file_saver_error_quark", libgtksourceview), UInt32, ())
+        ret
+    end
+    function finalize()
+        ret = ccall(("gtk_source_finalize", libgtksourceview), Nothing, ())
+        nothing
+    end
+    function get_major_version()
+        ret = ccall(("gtk_source_get_major_version", libgtksourceview), UInt32, ())
+        ret
+    end
+    function get_micro_version()
+        ret = ccall(("gtk_source_get_micro_version", libgtksourceview), UInt32, ())
+        ret
+    end
+    function get_minor_version()
+        ret = ccall(("gtk_source_get_minor_version", libgtksourceview), UInt32, ())
+        ret
+    end
+    function init()
+        ret = ccall(("gtk_source_init", libgtksourceview), Nothing, ())
+        nothing
+    end
+    function scheduler_add(_callback::Function)
+        begin
+            _callback_cfunc = @cfunction(GtkSourceSchedulerCallback, Cint, (Int64, Ref{Function}))
+            _callback_closure = GLib.gc_ref(_callback)
+        end
+        ret = ccall(("gtk_source_scheduler_add", libgtksourceview), UInt64, (Ptr{Cvoid}, Ptr{Nothing}), _callback_cfunc, _callback_closure)
+        ret
+    end
+    function scheduler_remove(_handler_id::Integer)
+        ret = ccall(("gtk_source_scheduler_remove", libgtksourceview), Nothing, (UInt64,), _handler_id)
+        nothing
+    end
+    function utils_escape_search_text(_text::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_utils_escape_search_text", libgtksourceview), Cstring, (Cstring,), _text)
+        ret2 = string_or_nothing(ret, true)
+        ret2
+    end
+    function utils_unescape_search_text(_text::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_utils_unescape_search_text", libgtksourceview), Cstring, (Cstring,), _text)
+        ret2 = string_or_nothing(ret, true)
+        ret2
+    end
+end))
+end

--- a/src/gen/gtksourceview_methods
+++ b/src/gen/gtksourceview_methods
@@ -1,0 +1,2189 @@
+quote
+$(Expr(:toplevel, quote
+    function copy(instance::GtkSourceEncoding)
+        ret = ccall(("gtk_source_encoding_copy", libgtksourceview), Ptr{GtkSourceEncoding}, (Ptr{GtkSourceEncoding},), instance)
+        ret2 = convert(GtkSourceEncoding, ret, true)
+        ret2
+    end
+    function free(instance::GtkSourceEncoding)
+        ret = ccall(("gtk_source_encoding_free", libgtksourceview), Nothing, (Ptr{GtkSourceEncoding},), instance)
+        nothing
+    end
+    function get_charset(instance::GtkSourceEncoding)
+        ret = ccall(("gtk_source_encoding_get_charset", libgtksourceview), Cstring, (Ptr{GtkSourceEncoding},), instance)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function get_name(instance::GtkSourceEncoding)
+        ret = ccall(("gtk_source_encoding_get_name", libgtksourceview), Cstring, (Ptr{GtkSourceEncoding},), instance)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function to_string(instance::GtkSourceEncoding)
+        ret = ccall(("gtk_source_encoding_to_string", libgtksourceview), Cstring, (Ptr{GtkSourceEncoding},), instance)
+        ret2 = string_or_nothing(ret, true)
+        ret2
+    end
+    function get_subregion(instance::Union{GtkSourceRegionIter, Ref{_GtkSourceRegionIter}})
+        m_start = Ref{_GtkTextIter}()
+        m_end = Ref{_GtkTextIter}()
+        ret = ccall(("gtk_source_region_iter_get_subregion", libgtksourceview), Cint, (Ptr{_GtkSourceRegionIter}, Ptr{_GtkTextIter}, Ptr{_GtkTextIter}), instance, m_start, m_end)
+        ret2 = convert(Bool, ret)
+        _start = m_start[]
+        _end = m_end[]
+        (ret2, _start, _end)
+    end
+    function is_end(instance::Union{GtkSourceRegionIter, Ref{_GtkSourceRegionIter}})
+        ret = ccall(("gtk_source_region_iter_is_end", libgtksourceview), Cint, (Ptr{_GtkSourceRegionIter},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function next(instance::Union{GtkSourceRegionIter, Ref{_GtkSourceRegionIter}})
+        ret = ccall(("gtk_source_region_iter_next", libgtksourceview), Cint, (Ptr{_GtkSourceRegionIter},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function Buffer_new(_table::Maybe(GtkTextTagTable))
+        _table_maybe = nothing_to_null(_table)
+        ret = ccall(("gtk_source_buffer_new", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), _table_maybe)
+        ret2 = GtkSourceBufferLeaf(ret, true)
+        ret2
+    end
+    function Buffer_new_with_language(_language::GtkSourceLanguage)
+        ret = ccall(("gtk_source_buffer_new_with_language", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), _language)
+        ret2 = GtkSourceBufferLeaf(ret, true)
+        ret2
+    end
+    function backward_iter_to_source_mark(instance::GtkSourceBuffer, _iter::Union{GtkTextIter, Ref{_GtkTextIter}}, _category::Maybe(Union{AbstractString, Symbol}))
+        m_iter = Ref{_GtkTextIter}()
+        m_iter[] = Base.cconvert(_GtkTextIter, _iter)
+        _category_maybe = nothing_to_null(_category)
+        ret = ccall(("gtk_source_buffer_backward_iter_to_source_mark", libgtksourceview), Cint, (Ptr{GObject}, Ptr{_GtkTextIter}, Cstring), instance, m_iter, _category_maybe)
+        ret2 = convert(Bool, ret)
+        _iter = m_iter[]
+        (ret2, _iter)
+    end
+    function change_case(instance::GtkSourceBuffer, _case_type, _start::Union{GtkTextIter, Ref{_GtkTextIter}}, _end::Union{GtkTextIter, Ref{_GtkTextIter}})
+        ret = ccall(("gtk_source_buffer_change_case", libgtksourceview), Nothing, (Ptr{GObject}, UInt32, Ptr{_GtkTextIter}, Ptr{_GtkTextIter}), instance, _case_type, _start, _end)
+        nothing
+    end
+    function create_source_mark(instance::GtkSourceBuffer, _name::Maybe(Union{AbstractString, Symbol}), _category::Union{AbstractString, Symbol}, _where::Union{GtkTextIter, Ref{_GtkTextIter}})
+        _name_maybe = nothing_to_null(_name)
+        ret = ccall(("gtk_source_buffer_create_source_mark", libgtksourceview), Ptr{GObject}, (Ptr{GObject}, Cstring, Cstring, Ptr{_GtkTextIter}), instance, _name_maybe, _category, _where)
+        ret2 = convert(GtkSourceMark, ret, false)
+        ret2
+    end
+    function ensure_highlight(instance::GtkSourceBuffer, _start::Union{GtkTextIter, Ref{_GtkTextIter}}, _end::Union{GtkTextIter, Ref{_GtkTextIter}})
+        ret = ccall(("gtk_source_buffer_ensure_highlight", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{_GtkTextIter}, Ptr{_GtkTextIter}), instance, _start, _end)
+        nothing
+    end
+    function forward_iter_to_source_mark(instance::GtkSourceBuffer, _iter::Union{GtkTextIter, Ref{_GtkTextIter}}, _category::Maybe(Union{AbstractString, Symbol}))
+        m_iter = Ref{_GtkTextIter}()
+        m_iter[] = Base.cconvert(_GtkTextIter, _iter)
+        _category_maybe = nothing_to_null(_category)
+        ret = ccall(("gtk_source_buffer_forward_iter_to_source_mark", libgtksourceview), Cint, (Ptr{GObject}, Ptr{_GtkTextIter}, Cstring), instance, m_iter, _category_maybe)
+        ret2 = convert(Bool, ret)
+        _iter = m_iter[]
+        (ret2, _iter)
+    end
+    function get_context_classes_at_iter(instance::GtkSourceBuffer, _iter::Union{GtkTextIter, Ref{_GtkTextIter}})
+        ret = ccall(("gtk_source_buffer_get_context_classes_at_iter", libgtksourceview), Ptr{Cstring}, (Ptr{GObject}, Ptr{_GtkTextIter}), instance, _iter)
+        ret2 = begin
+                _len = length_zt(ret)
+                arrtemp = bytestring.(unsafe_wrap(Vector{Cstring}, ret, _len))
+                GLib.g_strfreev(ret)
+                arrtemp
+            end
+        ret2
+    end
+    function get_highlight_matching_brackets(instance::GtkSourceBuffer)
+        ret = ccall(("gtk_source_buffer_get_highlight_matching_brackets", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_highlight_syntax(instance::GtkSourceBuffer)
+        ret = ccall(("gtk_source_buffer_get_highlight_syntax", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_implicit_trailing_newline(instance::GtkSourceBuffer)
+        ret = ccall(("gtk_source_buffer_get_implicit_trailing_newline", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_language(instance::GtkSourceBuffer)
+        ret = ccall(("gtk_source_buffer_get_language", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert_if_not_null(GtkSourceLanguage, ret, false)
+        ret2
+    end
+    function get_loading(instance::GtkSourceBuffer)
+        ret = ccall(("gtk_source_buffer_get_loading", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_source_marks_at_iter(instance::GtkSourceBuffer, _iter::Union{GtkTextIter, Ref{_GtkTextIter}}, _category::Maybe(Union{AbstractString, Symbol}))
+        _category_maybe = nothing_to_null(_category)
+        ret = ccall(("gtk_source_buffer_get_source_marks_at_iter", libgtksourceview), Ptr{GLib._GSList{Ptr{GObject}}}, (Ptr{GObject}, Ptr{_GtkTextIter}, Cstring), instance, _iter, _category_maybe)
+        ret2 = GLib.GList(ret, false)
+        ret2
+    end
+    function get_source_marks_at_line(instance::GtkSourceBuffer, _line::Integer, _category::Maybe(Union{AbstractString, Symbol}))
+        _category_maybe = nothing_to_null(_category)
+        ret = ccall(("gtk_source_buffer_get_source_marks_at_line", libgtksourceview), Ptr{GLib._GSList{Ptr{GObject}}}, (Ptr{GObject}, Int32, Cstring), instance, _line, _category_maybe)
+        ret2 = GLib.GList(ret, false)
+        ret2
+    end
+    function get_style_scheme(instance::GtkSourceBuffer)
+        ret = ccall(("gtk_source_buffer_get_style_scheme", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert_if_not_null(GtkSourceStyleScheme, ret, false)
+        ret2
+    end
+    function iter_backward_to_context_class_toggle(instance::GtkSourceBuffer, _iter::Union{GtkTextIter, Ref{_GtkTextIter}}, _context_class::Union{AbstractString, Symbol})
+        m_iter = Ref{_GtkTextIter}()
+        m_iter[] = Base.cconvert(_GtkTextIter, _iter)
+        ret = ccall(("gtk_source_buffer_iter_backward_to_context_class_toggle", libgtksourceview), Cint, (Ptr{GObject}, Ptr{_GtkTextIter}, Cstring), instance, m_iter, _context_class)
+        ret2 = convert(Bool, ret)
+        _iter = m_iter[]
+        (ret2, _iter)
+    end
+    function iter_forward_to_context_class_toggle(instance::GtkSourceBuffer, _iter::Union{GtkTextIter, Ref{_GtkTextIter}}, _context_class::Union{AbstractString, Symbol})
+        m_iter = Ref{_GtkTextIter}()
+        m_iter[] = Base.cconvert(_GtkTextIter, _iter)
+        ret = ccall(("gtk_source_buffer_iter_forward_to_context_class_toggle", libgtksourceview), Cint, (Ptr{GObject}, Ptr{_GtkTextIter}, Cstring), instance, m_iter, _context_class)
+        ret2 = convert(Bool, ret)
+        _iter = m_iter[]
+        (ret2, _iter)
+    end
+    function iter_has_context_class(instance::GtkSourceBuffer, _iter::Union{GtkTextIter, Ref{_GtkTextIter}}, _context_class::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_buffer_iter_has_context_class", libgtksourceview), Cint, (Ptr{GObject}, Ptr{_GtkTextIter}, Cstring), instance, _iter, _context_class)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function join_lines(instance::GtkSourceBuffer, _start::Union{GtkTextIter, Ref{_GtkTextIter}}, _end::Union{GtkTextIter, Ref{_GtkTextIter}})
+        ret = ccall(("gtk_source_buffer_join_lines", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{_GtkTextIter}, Ptr{_GtkTextIter}), instance, _start, _end)
+        nothing
+    end
+    function remove_source_marks(instance::GtkSourceBuffer, _start::Union{GtkTextIter, Ref{_GtkTextIter}}, _end::Union{GtkTextIter, Ref{_GtkTextIter}}, _category::Maybe(Union{AbstractString, Symbol}))
+        _category_maybe = nothing_to_null(_category)
+        ret = ccall(("gtk_source_buffer_remove_source_marks", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{_GtkTextIter}, Ptr{_GtkTextIter}, Cstring), instance, _start, _end, _category_maybe)
+        nothing
+    end
+    function set_highlight_matching_brackets(instance::GtkSourceBuffer, _highlight::Bool)
+        ret = ccall(("gtk_source_buffer_set_highlight_matching_brackets", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _highlight)
+        nothing
+    end
+    function set_highlight_syntax(instance::GtkSourceBuffer, _highlight::Bool)
+        ret = ccall(("gtk_source_buffer_set_highlight_syntax", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _highlight)
+        nothing
+    end
+    function set_implicit_trailing_newline(instance::GtkSourceBuffer, _implicit_trailing_newline::Bool)
+        ret = ccall(("gtk_source_buffer_set_implicit_trailing_newline", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _implicit_trailing_newline)
+        nothing
+    end
+    function set_language(instance::GtkSourceBuffer, _language::Maybe(GtkSourceLanguage))
+        _language_maybe = nothing_to_null(_language)
+        ret = ccall(("gtk_source_buffer_set_language", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _language_maybe)
+        nothing
+    end
+    function set_style_scheme(instance::GtkSourceBuffer, _scheme::Maybe(GtkSourceStyleScheme))
+        _scheme_maybe = nothing_to_null(_scheme)
+        ret = ccall(("gtk_source_buffer_set_style_scheme", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _scheme_maybe)
+        nothing
+    end
+    function sort_lines(instance::GtkSourceBuffer, _start::Union{GtkTextIter, Ref{_GtkTextIter}}, _end::Union{GtkTextIter, Ref{_GtkTextIter}}, _flags, _column::Integer)
+        ret = ccall(("gtk_source_buffer_sort_lines", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{_GtkTextIter}, Ptr{_GtkTextIter}, UInt32, Int32), instance, _start, _end, _flags, _column)
+        nothing
+    end
+    function fuzzy_highlight(_haystack::Union{AbstractString, Symbol}, _casefold_query::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_completion_fuzzy_highlight", libgtksourceview), Ptr{PangoAttrList}, (Cstring, Cstring), _haystack, _casefold_query)
+        ret2 = convert_if_not_null(PangoAttrList, ret, true)
+        ret2
+    end
+    function fuzzy_match(_haystack::Maybe(Union{AbstractString, Symbol}), _casefold_needle::Union{AbstractString, Symbol})
+        _haystack_maybe = nothing_to_null(_haystack)
+        m_priority = Ref{UInt32}()
+        ret = ccall(("gtk_source_completion_fuzzy_match", libgtksourceview), Cint, (Cstring, Cstring, Ptr{UInt32}), _haystack_maybe, _casefold_needle, m_priority)
+        ret2 = convert(Bool, ret)
+        _priority = m_priority[]
+        (ret2, _priority)
+    end
+    function add_provider(instance::GtkSourceCompletion, _provider::GtkSourceCompletionProvider)
+        ret = ccall(("gtk_source_completion_add_provider", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _provider)
+        nothing
+    end
+    function block_interactive(instance::GtkSourceCompletion)
+        ret = ccall(("gtk_source_completion_block_interactive", libgtksourceview), Nothing, (Ptr{GObject},), instance)
+        nothing
+    end
+    function get_buffer(instance::GtkSourceCompletion)
+        ret = ccall(("gtk_source_completion_get_buffer", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceBuffer, ret, false)
+        ret2
+    end
+    function get_page_size(instance::GtkSourceCompletion)
+        ret = ccall(("gtk_source_completion_get_page_size", libgtksourceview), UInt32, (Ptr{GObject},), instance)
+        ret
+    end
+    function get_view(instance::GtkSourceCompletion)
+        ret = ccall(("gtk_source_completion_get_view", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceView, ret, false)
+        ret2
+    end
+    function hide(instance::GtkSourceCompletion)
+        ret = ccall(("gtk_source_completion_hide", libgtksourceview), Nothing, (Ptr{GObject},), instance)
+        nothing
+    end
+    function remove_provider(instance::GtkSourceCompletion, _provider::GtkSourceCompletionProvider)
+        ret = ccall(("gtk_source_completion_remove_provider", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _provider)
+        nothing
+    end
+    function set_page_size(instance::GtkSourceCompletion, _page_size::Integer)
+        ret = ccall(("gtk_source_completion_set_page_size", libgtksourceview), Nothing, (Ptr{GObject}, UInt32), instance, _page_size)
+        nothing
+    end
+    function show(instance::GtkSourceCompletion)
+        ret = ccall(("gtk_source_completion_show", libgtksourceview), Nothing, (Ptr{GObject},), instance)
+        nothing
+    end
+    function unblock_interactive(instance::GtkSourceCompletion)
+        ret = ccall(("gtk_source_completion_unblock_interactive", libgtksourceview), Nothing, (Ptr{GObject},), instance)
+        nothing
+    end
+    function get_column(instance::GtkSourceCompletionCell)
+        ret = ccall(("gtk_source_completion_cell_get_column", libgtksourceview), UInt32, (Ptr{GObject},), instance)
+        ret2 = CompletionColumn(ret)
+        ret2
+    end
+    function get_widget(instance::GtkSourceCompletionCell)
+        ret = ccall(("gtk_source_completion_cell_get_widget", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert_if_not_null(GtkWidget, ret, false)
+        ret2
+    end
+    function set_gicon(instance::GtkSourceCompletionCell, _gicon::GIcon)
+        ret = ccall(("gtk_source_completion_cell_set_gicon", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _gicon)
+        nothing
+    end
+    function set_icon_name(instance::GtkSourceCompletionCell, _icon_name::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_completion_cell_set_icon_name", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _icon_name)
+        nothing
+    end
+    function set_markup(instance::GtkSourceCompletionCell, _markup::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_completion_cell_set_markup", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _markup)
+        nothing
+    end
+    function set_paintable(instance::GtkSourceCompletionCell, _paintable::GdkPaintable)
+        ret = ccall(("gtk_source_completion_cell_set_paintable", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _paintable)
+        nothing
+    end
+    function set_text(instance::GtkSourceCompletionCell, _text::Maybe(Union{AbstractString, Symbol}))
+        _text_maybe = nothing_to_null(_text)
+        ret = ccall(("gtk_source_completion_cell_set_text", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _text_maybe)
+        nothing
+    end
+    function set_text_with_attributes(instance::GtkSourceCompletionCell, _text::Union{AbstractString, Symbol}, _attrs::PangoAttrList)
+        ret = ccall(("gtk_source_completion_cell_set_text_with_attributes", libgtksourceview), Nothing, (Ptr{GObject}, Cstring, Ptr{PangoAttrList}), instance, _text, _attrs)
+        nothing
+    end
+    function set_widget(instance::GtkSourceCompletionCell, _child::GtkWidget)
+        ret = ccall(("gtk_source_completion_cell_set_widget", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _child)
+        nothing
+    end
+    function get_activation(instance::GtkSourceCompletionContext)
+        ret = ccall(("gtk_source_completion_context_get_activation", libgtksourceview), UInt32, (Ptr{GObject},), instance)
+        ret2 = CompletionActivation(ret)
+        ret2
+    end
+    function get_bounds(instance::GtkSourceCompletionContext)
+        m_begin = Ref{_GtkTextIter}()
+        m_end = Ref{_GtkTextIter}()
+        ret = ccall(("gtk_source_completion_context_get_bounds", libgtksourceview), Cint, (Ptr{GObject}, Ptr{_GtkTextIter}, Ptr{_GtkTextIter}), instance, m_begin, m_end)
+        ret2 = convert(Bool, ret)
+        _begin = m_begin[]
+        _end = m_end[]
+        (ret2, _begin, _end)
+    end
+    function get_buffer(instance::GtkSourceCompletionContext)
+        ret = ccall(("gtk_source_completion_context_get_buffer", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert_if_not_null(GtkSourceBuffer, ret, false)
+        ret2
+    end
+    function get_busy(instance::GtkSourceCompletionContext)
+        ret = ccall(("gtk_source_completion_context_get_busy", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_completion(instance::GtkSourceCompletionContext)
+        ret = ccall(("gtk_source_completion_context_get_completion", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert_if_not_null(GtkSourceCompletion, ret, false)
+        ret2
+    end
+    function get_empty(instance::GtkSourceCompletionContext)
+        ret = ccall(("gtk_source_completion_context_get_empty", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_language(instance::GtkSourceCompletionContext)
+        ret = ccall(("gtk_source_completion_context_get_language", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert_if_not_null(GtkSourceLanguage, ret, false)
+        ret2
+    end
+    function get_proposals_for_provider(instance::GtkSourceCompletionContext, _provider::GtkSourceCompletionProvider)
+        ret = ccall(("gtk_source_completion_context_get_proposals_for_provider", libgtksourceview), Ptr{GObject}, (Ptr{GObject}, Ptr{GObject}), instance, _provider)
+        ret2 = GLib.find_leaf_type_if_not_null(ret, false)
+        ret2
+    end
+    function get_view(instance::GtkSourceCompletionContext)
+        ret = ccall(("gtk_source_completion_context_get_view", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert_if_not_null(GtkSourceView, ret, false)
+        ret2
+    end
+    function get_word(instance::GtkSourceCompletionContext)
+        ret = ccall(("gtk_source_completion_context_get_word", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, true)
+        ret2
+    end
+    function list_providers(instance::GtkSourceCompletionContext)
+        ret = ccall(("gtk_source_completion_context_list_providers", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = begin
+                leaftype = GLib.find_leaf_type(ret)
+                convert(leaftype, ret, true)
+            end
+        ret2
+    end
+    function set_proposals_for_provider(instance::GtkSourceCompletionContext, _provider::GtkSourceCompletionProvider, _results::Maybe(GListModel))
+        _results_maybe = nothing_to_null(_results)
+        ret = ccall(("gtk_source_completion_context_set_proposals_for_provider", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}, Ptr{GObject}), instance, _provider, _results_maybe)
+        nothing
+    end
+    function CompletionSnippets_new()
+        ret = ccall(("gtk_source_completion_snippets_new", libgtksourceview), Ptr{GObject}, ())
+        ret2 = GtkSourceCompletionSnippetsLeaf(ret, true)
+        ret2
+    end
+    function CompletionWords_new(_title::Maybe(Union{AbstractString, Symbol}))
+        _title_maybe = nothing_to_null(_title)
+        ret = ccall(("gtk_source_completion_words_new", libgtksourceview), Ptr{GObject}, (Cstring,), _title_maybe)
+        ret2 = GtkSourceCompletionWordsLeaf(ret, true)
+        ret2
+    end
+    function register(instance::GtkSourceCompletionWords, _buffer::GtkTextBuffer)
+        ret = ccall(("gtk_source_completion_words_register", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _buffer)
+        nothing
+    end
+    function unregister(instance::GtkSourceCompletionWords, _buffer::GtkTextBuffer)
+        ret = ccall(("gtk_source_completion_words_unregister", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _buffer)
+        nothing
+    end
+    function File_new()
+        ret = ccall(("gtk_source_file_new", libgtksourceview), Ptr{GObject}, ())
+        ret2 = GtkSourceFileLeaf(ret, true)
+        ret2
+    end
+    function check_file_on_disk(instance::GtkSourceFile)
+        ret = ccall(("gtk_source_file_check_file_on_disk", libgtksourceview), Nothing, (Ptr{GObject},), instance)
+        nothing
+    end
+    function get_compression_type(instance::GtkSourceFile)
+        ret = ccall(("gtk_source_file_get_compression_type", libgtksourceview), UInt32, (Ptr{GObject},), instance)
+        ret2 = CompressionType(ret)
+        ret2
+    end
+    function get_encoding(instance::GtkSourceFile)
+        ret = ccall(("gtk_source_file_get_encoding", libgtksourceview), Ptr{GtkSourceEncoding}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceEncoding, ret, false)
+        ret2
+    end
+    function get_location(instance::GtkSourceFile)
+        ret = ccall(("gtk_source_file_get_location", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = begin
+                leaftype = GLib.find_leaf_type(ret)
+                convert(leaftype, ret, false)
+            end
+        ret2
+    end
+    function get_newline_type(instance::GtkSourceFile)
+        ret = ccall(("gtk_source_file_get_newline_type", libgtksourceview), UInt32, (Ptr{GObject},), instance)
+        ret2 = NewlineType(ret)
+        ret2
+    end
+    function is_deleted(instance::GtkSourceFile)
+        ret = ccall(("gtk_source_file_is_deleted", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function is_externally_modified(instance::GtkSourceFile)
+        ret = ccall(("gtk_source_file_is_externally_modified", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function is_local(instance::GtkSourceFile)
+        ret = ccall(("gtk_source_file_is_local", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function is_readonly(instance::GtkSourceFile)
+        ret = ccall(("gtk_source_file_is_readonly", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function set_location(instance::GtkSourceFile, _location::Maybe(GFile))
+        _location_maybe = nothing_to_null(_location)
+        ret = ccall(("gtk_source_file_set_location", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _location_maybe)
+        nothing
+    end
+    function FileLoader_new(_buffer::GtkSourceBuffer, _file::GtkSourceFile)
+        ret = ccall(("gtk_source_file_loader_new", libgtksourceview), Ptr{GObject}, (Ptr{GObject}, Ptr{GObject}), _buffer, _file)
+        ret2 = GtkSourceFileLoaderLeaf(ret, true)
+        ret2
+    end
+    function FileLoader_new_from_stream(_buffer::GtkSourceBuffer, _file::GtkSourceFile, _stream::GInputStream)
+        ret = ccall(("gtk_source_file_loader_new_from_stream", libgtksourceview), Ptr{GObject}, (Ptr{GObject}, Ptr{GObject}, Ptr{GObject}), _buffer, _file, _stream)
+        ret2 = GtkSourceFileLoaderLeaf(ret, true)
+        ret2
+    end
+    function get_buffer(instance::GtkSourceFileLoader)
+        ret = ccall(("gtk_source_file_loader_get_buffer", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceBuffer, ret, false)
+        ret2
+    end
+    function get_compression_type(instance::GtkSourceFileLoader)
+        ret = ccall(("gtk_source_file_loader_get_compression_type", libgtksourceview), UInt32, (Ptr{GObject},), instance)
+        ret2 = CompressionType(ret)
+        ret2
+    end
+    function get_encoding(instance::GtkSourceFileLoader)
+        ret = ccall(("gtk_source_file_loader_get_encoding", libgtksourceview), Ptr{GtkSourceEncoding}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceEncoding, ret, false)
+        ret2
+    end
+    function get_file(instance::GtkSourceFileLoader)
+        ret = ccall(("gtk_source_file_loader_get_file", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceFile, ret, false)
+        ret2
+    end
+    function get_input_stream(instance::GtkSourceFileLoader)
+        ret = ccall(("gtk_source_file_loader_get_input_stream", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert_if_not_null(GInputStream, ret, false)
+        ret2
+    end
+    function get_location(instance::GtkSourceFileLoader)
+        ret = ccall(("gtk_source_file_loader_get_location", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = GLib.find_leaf_type_if_not_null(ret, false)
+        ret2
+    end
+    function get_newline_type(instance::GtkSourceFileLoader)
+        ret = ccall(("gtk_source_file_loader_get_newline_type", libgtksourceview), UInt32, (Ptr{GObject},), instance)
+        ret2 = NewlineType(ret)
+        ret2
+    end
+    function load_finish(instance::GtkSourceFileLoader, _result::GAsyncResult)
+        err = err_buf()
+        ret = ccall(("gtk_source_file_loader_load_finish", libgtksourceview), Cint, (Ptr{GObject}, Ptr{GObject}, Ptr{Ptr{GError}}), instance, _result, err)
+        check_err(err)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function set_candidate_encodings(instance::GtkSourceFileLoader, _candidate_encodings::GLib.LList{GLib._GSList{GtkSourceEncoding}})
+        ret = ccall(("gtk_source_file_loader_set_candidate_encodings", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GLib._GSList{GtkSourceEncoding}}), instance, _candidate_encodings)
+        nothing
+    end
+    function FileSaver_new(_buffer::GtkSourceBuffer, _file::GtkSourceFile)
+        ret = ccall(("gtk_source_file_saver_new", libgtksourceview), Ptr{GObject}, (Ptr{GObject}, Ptr{GObject}), _buffer, _file)
+        ret2 = GtkSourceFileSaverLeaf(ret, true)
+        ret2
+    end
+    function FileSaver_new_with_target(_buffer::GtkSourceBuffer, _file::GtkSourceFile, _target_location::GFile)
+        ret = ccall(("gtk_source_file_saver_new_with_target", libgtksourceview), Ptr{GObject}, (Ptr{GObject}, Ptr{GObject}, Ptr{GObject}), _buffer, _file, _target_location)
+        ret2 = GtkSourceFileSaverLeaf(ret, true)
+        ret2
+    end
+    function get_buffer(instance::GtkSourceFileSaver)
+        ret = ccall(("gtk_source_file_saver_get_buffer", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceBuffer, ret, false)
+        ret2
+    end
+    function get_compression_type(instance::GtkSourceFileSaver)
+        ret = ccall(("gtk_source_file_saver_get_compression_type", libgtksourceview), UInt32, (Ptr{GObject},), instance)
+        ret2 = CompressionType(ret)
+        ret2
+    end
+    function get_encoding(instance::GtkSourceFileSaver)
+        ret = ccall(("gtk_source_file_saver_get_encoding", libgtksourceview), Ptr{GtkSourceEncoding}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceEncoding, ret, false)
+        ret2
+    end
+    function get_file(instance::GtkSourceFileSaver)
+        ret = ccall(("gtk_source_file_saver_get_file", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceFile, ret, false)
+        ret2
+    end
+    function get_flags(instance::GtkSourceFileSaver)
+        ret = ccall(("gtk_source_file_saver_get_flags", libgtksourceview), UInt32, (Ptr{GObject},), instance)
+        ret2 = FileSaverFlags(ret)
+        ret2
+    end
+    function get_location(instance::GtkSourceFileSaver)
+        ret = ccall(("gtk_source_file_saver_get_location", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = begin
+                leaftype = GLib.find_leaf_type(ret)
+                convert(leaftype, ret, false)
+            end
+        ret2
+    end
+    function get_newline_type(instance::GtkSourceFileSaver)
+        ret = ccall(("gtk_source_file_saver_get_newline_type", libgtksourceview), UInt32, (Ptr{GObject},), instance)
+        ret2 = NewlineType(ret)
+        ret2
+    end
+    function save_finish(instance::GtkSourceFileSaver, _result::GAsyncResult)
+        err = err_buf()
+        ret = ccall(("gtk_source_file_saver_save_finish", libgtksourceview), Cint, (Ptr{GObject}, Ptr{GObject}, Ptr{Ptr{GError}}), instance, _result, err)
+        check_err(err)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function set_compression_type(instance::GtkSourceFileSaver, _compression_type)
+        ret = ccall(("gtk_source_file_saver_set_compression_type", libgtksourceview), Nothing, (Ptr{GObject}, UInt32), instance, _compression_type)
+        nothing
+    end
+    function set_encoding(instance::GtkSourceFileSaver, _encoding::Maybe(GtkSourceEncoding))
+        _encoding_maybe = nothing_to_null(_encoding)
+        ret = ccall(("gtk_source_file_saver_set_encoding", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GtkSourceEncoding}), instance, _encoding_maybe)
+        nothing
+    end
+    function set_flags(instance::GtkSourceFileSaver, _flags)
+        ret = ccall(("gtk_source_file_saver_set_flags", libgtksourceview), Nothing, (Ptr{GObject}, UInt32), instance, _flags)
+        nothing
+    end
+    function set_newline_type(instance::GtkSourceFileSaver, _newline_type)
+        ret = ccall(("gtk_source_file_saver_set_newline_type", libgtksourceview), Nothing, (Ptr{GObject}, UInt32), instance, _newline_type)
+        nothing
+    end
+    function get_view(instance::GtkSourceGutter)
+        ret = ccall(("gtk_source_gutter_get_view", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceView, ret, false)
+        ret2
+    end
+    function insert(instance::GtkSourceGutter, _renderer::GtkSourceGutterRenderer, _position::Integer)
+        ret = ccall(("gtk_source_gutter_insert", libgtksourceview), Cint, (Ptr{GObject}, Ptr{GObject}, Int32), instance, _renderer, _position)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function remove(instance::GtkSourceGutter, _renderer::GtkSourceGutterRenderer)
+        ret = ccall(("gtk_source_gutter_remove", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _renderer)
+        nothing
+    end
+    function reorder(instance::GtkSourceGutter, _renderer::GtkSourceGutterRenderer, _position::Integer)
+        ret = ccall(("gtk_source_gutter_reorder", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}, Int32), instance, _renderer, _position)
+        nothing
+    end
+    function add_class(instance::GtkSourceGutterLines, _line::Integer, _name::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_gutter_lines_add_class", libgtksourceview), Nothing, (Ptr{GObject}, UInt32, Cstring), instance, _line, _name)
+        nothing
+    end
+    function add_qclass(instance::GtkSourceGutterLines, _line::Integer, _qname::Integer)
+        ret = ccall(("gtk_source_gutter_lines_add_qclass", libgtksourceview), Nothing, (Ptr{GObject}, UInt32, UInt32), instance, _line, _qname)
+        nothing
+    end
+    function get_buffer(instance::GtkSourceGutterLines)
+        ret = ccall(("gtk_source_gutter_lines_get_buffer", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkTextBuffer, ret, false)
+        ret2
+    end
+    function get_first(instance::GtkSourceGutterLines)
+        ret = ccall(("gtk_source_gutter_lines_get_first", libgtksourceview), UInt32, (Ptr{GObject},), instance)
+        ret
+    end
+    function get_iter_at_line(instance::GtkSourceGutterLines, _line::Integer)
+        m_iter = Ref{_GtkTextIter}()
+        ret = ccall(("gtk_source_gutter_lines_get_iter_at_line", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{_GtkTextIter}, UInt32), instance, m_iter, _line)
+        _iter = m_iter[]
+        _iter
+    end
+    function get_last(instance::GtkSourceGutterLines)
+        ret = ccall(("gtk_source_gutter_lines_get_last", libgtksourceview), UInt32, (Ptr{GObject},), instance)
+        ret
+    end
+    function get_line_yrange(instance::GtkSourceGutterLines, _line::Integer, _mode)
+        m_y = Ref{Int32}()
+        m_height = Ref{Int32}()
+        ret = ccall(("gtk_source_gutter_lines_get_line_yrange", libgtksourceview), Nothing, (Ptr{GObject}, UInt32, UInt32, Ptr{Int32}, Ptr{Int32}), instance, _line, _mode, m_y, m_height)
+        _y = m_y[]
+        _height = m_height[]
+        (_y, _height)
+    end
+    function get_view(instance::GtkSourceGutterLines)
+        ret = ccall(("gtk_source_gutter_lines_get_view", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkTextView, ret, false)
+        ret2
+    end
+    function has_any_class(instance::GtkSourceGutterLines, _line::Integer)
+        ret = ccall(("gtk_source_gutter_lines_has_any_class", libgtksourceview), Cint, (Ptr{GObject}, UInt32), instance, _line)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function has_class(instance::GtkSourceGutterLines, _line::Integer, _name::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_gutter_lines_has_class", libgtksourceview), Cint, (Ptr{GObject}, UInt32, Cstring), instance, _line, _name)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function has_qclass(instance::GtkSourceGutterLines, _line::Integer, _qname::Integer)
+        ret = ccall(("gtk_source_gutter_lines_has_qclass", libgtksourceview), Cint, (Ptr{GObject}, UInt32, UInt32), instance, _line, _qname)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function is_cursor(instance::GtkSourceGutterLines, _line::Integer)
+        ret = ccall(("gtk_source_gutter_lines_is_cursor", libgtksourceview), Cint, (Ptr{GObject}, UInt32), instance, _line)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function is_prelit(instance::GtkSourceGutterLines, _line::Integer)
+        ret = ccall(("gtk_source_gutter_lines_is_prelit", libgtksourceview), Cint, (Ptr{GObject}, UInt32), instance, _line)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function is_selected(instance::GtkSourceGutterLines, _line::Integer)
+        ret = ccall(("gtk_source_gutter_lines_is_selected", libgtksourceview), Cint, (Ptr{GObject}, UInt32), instance, _line)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function remove_class(instance::GtkSourceGutterLines, _line::Integer, _name::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_gutter_lines_remove_class", libgtksourceview), Nothing, (Ptr{GObject}, UInt32, Cstring), instance, _line, _name)
+        nothing
+    end
+    function remove_qclass(instance::GtkSourceGutterLines, _line::Integer, _qname::Integer)
+        ret = ccall(("gtk_source_gutter_lines_remove_qclass", libgtksourceview), Nothing, (Ptr{GObject}, UInt32, UInt32), instance, _line, _qname)
+        nothing
+    end
+    function activate(instance::GtkSourceGutterRenderer, _iter::Union{GtkTextIter, Ref{_GtkTextIter}}, _area::Union{GdkRectangle, Ref{_GdkRectangle}}, _button::Integer, _state, _n_presses::Integer)
+        ret = ccall(("gtk_source_gutter_renderer_activate", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{_GtkTextIter}, Ptr{_GdkRectangle}, UInt32, UInt32, Int32), instance, _iter, _area, _button, _state, _n_presses)
+        nothing
+    end
+    function align_cell(instance::GtkSourceGutterRenderer, _line::Integer, _width::Real, _height::Real)
+        m_x = Ref{Float32}()
+        m_y = Ref{Float32}()
+        ret = ccall(("gtk_source_gutter_renderer_align_cell", libgtksourceview), Nothing, (Ptr{GObject}, UInt32, Float32, Float32, Ptr{Float32}, Ptr{Float32}), instance, _line, _width, _height, m_x, m_y)
+        _x = m_x[]
+        _y = m_y[]
+        (_x, _y)
+    end
+    function get_alignment_mode(instance::GtkSourceGutterRenderer)
+        ret = ccall(("gtk_source_gutter_renderer_get_alignment_mode", libgtksourceview), UInt32, (Ptr{GObject},), instance)
+        ret2 = GutterRendererAlignmentMode(ret)
+        ret2
+    end
+    function get_buffer(instance::GtkSourceGutterRenderer)
+        ret = ccall(("gtk_source_gutter_renderer_get_buffer", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert_if_not_null(GtkSourceBuffer, ret, false)
+        ret2
+    end
+    function get_view(instance::GtkSourceGutterRenderer)
+        ret = ccall(("gtk_source_gutter_renderer_get_view", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceView, ret, false)
+        ret2
+    end
+    function get_xalign(instance::GtkSourceGutterRenderer)
+        ret = ccall(("gtk_source_gutter_renderer_get_xalign", libgtksourceview), Float32, (Ptr{GObject},), instance)
+        ret
+    end
+    function get_xpad(instance::GtkSourceGutterRenderer)
+        ret = ccall(("gtk_source_gutter_renderer_get_xpad", libgtksourceview), Int32, (Ptr{GObject},), instance)
+        ret
+    end
+    function get_yalign(instance::GtkSourceGutterRenderer)
+        ret = ccall(("gtk_source_gutter_renderer_get_yalign", libgtksourceview), Float32, (Ptr{GObject},), instance)
+        ret
+    end
+    function get_ypad(instance::GtkSourceGutterRenderer)
+        ret = ccall(("gtk_source_gutter_renderer_get_ypad", libgtksourceview), Int32, (Ptr{GObject},), instance)
+        ret
+    end
+    function query_activatable(instance::GtkSourceGutterRenderer, _iter::Union{GtkTextIter, Ref{_GtkTextIter}}, _area::Union{GdkRectangle, Ref{_GdkRectangle}})
+        ret = ccall(("gtk_source_gutter_renderer_query_activatable", libgtksourceview), Cint, (Ptr{GObject}, Ptr{_GtkTextIter}, Ptr{_GdkRectangle}), instance, _iter, _area)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function set_alignment_mode(instance::GtkSourceGutterRenderer, _mode)
+        ret = ccall(("gtk_source_gutter_renderer_set_alignment_mode", libgtksourceview), Nothing, (Ptr{GObject}, UInt32), instance, _mode)
+        nothing
+    end
+    function set_xalign(instance::GtkSourceGutterRenderer, _xalign::Real)
+        ret = ccall(("gtk_source_gutter_renderer_set_xalign", libgtksourceview), Nothing, (Ptr{GObject}, Float32), instance, _xalign)
+        nothing
+    end
+    function set_xpad(instance::GtkSourceGutterRenderer, _xpad::Integer)
+        ret = ccall(("gtk_source_gutter_renderer_set_xpad", libgtksourceview), Nothing, (Ptr{GObject}, Int32), instance, _xpad)
+        nothing
+    end
+    function set_yalign(instance::GtkSourceGutterRenderer, _yalign::Real)
+        ret = ccall(("gtk_source_gutter_renderer_set_yalign", libgtksourceview), Nothing, (Ptr{GObject}, Float32), instance, _yalign)
+        nothing
+    end
+    function set_ypad(instance::GtkSourceGutterRenderer, _ypad::Integer)
+        ret = ccall(("gtk_source_gutter_renderer_set_ypad", libgtksourceview), Nothing, (Ptr{GObject}, Int32), instance, _ypad)
+        nothing
+    end
+    function GutterRendererPixbuf_new()
+        ret = ccall(("gtk_source_gutter_renderer_pixbuf_new", libgtksourceview), Ptr{GObject}, ())
+        ret2 = GtkSourceGutterRendererPixbufLeaf(ret, true)
+        ret2
+    end
+    function get_gicon(instance::GtkSourceGutterRendererPixbuf)
+        ret = ccall(("gtk_source_gutter_renderer_pixbuf_get_gicon", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = begin
+                leaftype = GLib.find_leaf_type(ret)
+                convert(leaftype, ret, false)
+            end
+        ret2
+    end
+    function get_icon_name(instance::GtkSourceGutterRendererPixbuf)
+        ret = ccall(("gtk_source_gutter_renderer_pixbuf_get_icon_name", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function get_paintable(instance::GtkSourceGutterRendererPixbuf)
+        ret = ccall(("gtk_source_gutter_renderer_pixbuf_get_paintable", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = GLib.find_leaf_type_if_not_null(ret, false)
+        ret2
+    end
+    function get_pixbuf(instance::GtkSourceGutterRendererPixbuf)
+        ret = ccall(("gtk_source_gutter_renderer_pixbuf_get_pixbuf", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GdkPixbuf, ret, false)
+        ret2
+    end
+    function overlay_paintable(instance::GtkSourceGutterRendererPixbuf, _paintable::GdkPaintable)
+        ret = ccall(("gtk_source_gutter_renderer_pixbuf_overlay_paintable", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _paintable)
+        nothing
+    end
+    function set_gicon(instance::GtkSourceGutterRendererPixbuf, _icon::Maybe(GIcon))
+        _icon_maybe = nothing_to_null(_icon)
+        ret = ccall(("gtk_source_gutter_renderer_pixbuf_set_gicon", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _icon_maybe)
+        nothing
+    end
+    function set_icon_name(instance::GtkSourceGutterRendererPixbuf, _icon_name::Maybe(Union{AbstractString, Symbol}))
+        _icon_name_maybe = nothing_to_null(_icon_name)
+        ret = ccall(("gtk_source_gutter_renderer_pixbuf_set_icon_name", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _icon_name_maybe)
+        nothing
+    end
+    function set_paintable(instance::GtkSourceGutterRendererPixbuf, _paintable::Maybe(GdkPaintable))
+        _paintable_maybe = nothing_to_null(_paintable)
+        ret = ccall(("gtk_source_gutter_renderer_pixbuf_set_paintable", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _paintable_maybe)
+        nothing
+    end
+    function set_pixbuf(instance::GtkSourceGutterRendererPixbuf, _pixbuf::Maybe(GdkPixbuf))
+        _pixbuf_maybe = nothing_to_null(_pixbuf)
+        ret = ccall(("gtk_source_gutter_renderer_pixbuf_set_pixbuf", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _pixbuf_maybe)
+        nothing
+    end
+    function GutterRendererText_new()
+        ret = ccall(("gtk_source_gutter_renderer_text_new", libgtksourceview), Ptr{GObject}, ())
+        ret2 = GtkSourceGutterRendererTextLeaf(ret, true)
+        ret2
+    end
+    function measure(instance::GtkSourceGutterRendererText, _text::Union{AbstractString, Symbol})
+        m_width = Ref{Int32}()
+        m_height = Ref{Int32}()
+        ret = ccall(("gtk_source_gutter_renderer_text_measure", libgtksourceview), Nothing, (Ptr{GObject}, Cstring, Ptr{Int32}, Ptr{Int32}), instance, _text, m_width, m_height)
+        _width = m_width[]
+        _height = m_height[]
+        (_width, _height)
+    end
+    function measure_markup(instance::GtkSourceGutterRendererText, _markup::Union{AbstractString, Symbol})
+        m_width = Ref{Int32}()
+        m_height = Ref{Int32}()
+        ret = ccall(("gtk_source_gutter_renderer_text_measure_markup", libgtksourceview), Nothing, (Ptr{GObject}, Cstring, Ptr{Int32}, Ptr{Int32}), instance, _markup, m_width, m_height)
+        _width = m_width[]
+        _height = m_height[]
+        (_width, _height)
+    end
+    function set_markup(instance::GtkSourceGutterRendererText, _markup::Union{AbstractString, Symbol}, _length::Integer)
+        ret = ccall(("gtk_source_gutter_renderer_text_set_markup", libgtksourceview), Nothing, (Ptr{GObject}, Cstring, Int32), instance, _markup, _length)
+        nothing
+    end
+    function set_text(instance::GtkSourceGutterRendererText, _text::Union{AbstractString, Symbol}, _length::Integer)
+        ret = ccall(("gtk_source_gutter_renderer_text_set_text", libgtksourceview), Nothing, (Ptr{GObject}, Cstring, Int32), instance, _text, _length)
+        nothing
+    end
+    function add_provider(instance::GtkSourceHover, _provider::GtkSourceHoverProvider)
+        ret = ccall(("gtk_source_hover_add_provider", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _provider)
+        nothing
+    end
+    function remove_provider(instance::GtkSourceHover, _provider::GtkSourceHoverProvider)
+        ret = ccall(("gtk_source_hover_remove_provider", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _provider)
+        nothing
+    end
+    function get_bounds(instance::GtkSourceHoverContext)
+        m_begin = Ref{_GtkTextIter}()
+        m_end = Ref{_GtkTextIter}()
+        ret = ccall(("gtk_source_hover_context_get_bounds", libgtksourceview), Cint, (Ptr{GObject}, Ptr{_GtkTextIter}, Ptr{_GtkTextIter}), instance, m_begin, m_end)
+        ret2 = convert(Bool, ret)
+        _begin = m_begin[]
+        _end = m_end[]
+        (ret2, _begin, _end)
+    end
+    function get_buffer(instance::GtkSourceHoverContext)
+        ret = ccall(("gtk_source_hover_context_get_buffer", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceBuffer, ret, false)
+        ret2
+    end
+    function get_iter(instance::GtkSourceHoverContext, _iter::Union{GtkTextIter, Ref{_GtkTextIter}})
+        ret = ccall(("gtk_source_hover_context_get_iter", libgtksourceview), Cint, (Ptr{GObject}, Ptr{_GtkTextIter}), instance, _iter)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_view(instance::GtkSourceHoverContext)
+        ret = ccall(("gtk_source_hover_context_get_view", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceView, ret, false)
+        ret2
+    end
+    function append(instance::GtkSourceHoverDisplay, _child::GtkWidget)
+        ret = ccall(("gtk_source_hover_display_append", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _child)
+        nothing
+    end
+    function insert_after(instance::GtkSourceHoverDisplay, _child::GtkWidget, _sibling::GtkWidget)
+        ret = ccall(("gtk_source_hover_display_insert_after", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}, Ptr{GObject}), instance, _child, _sibling)
+        nothing
+    end
+    function prepend(instance::GtkSourceHoverDisplay, _child::GtkWidget)
+        ret = ccall(("gtk_source_hover_display_prepend", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _child)
+        nothing
+    end
+    function remove(instance::GtkSourceHoverDisplay, _child::GtkWidget)
+        ret = ccall(("gtk_source_hover_display_remove", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _child)
+        nothing
+    end
+    function get_globs(instance::GtkSourceLanguage)
+        ret = ccall(("gtk_source_language_get_globs", libgtksourceview), Ptr{Cstring}, (Ptr{GObject},), instance)
+        ret2 = begin
+                _len = length_zt(ret)
+                arrtemp = bytestring.(unsafe_wrap(Vector{Cstring}, ret, _len))
+                GLib.g_strfreev(ret)
+                arrtemp
+            end
+        ret2
+    end
+    function get_hidden(instance::GtkSourceLanguage)
+        ret = ccall(("gtk_source_language_get_hidden", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_id(instance::GtkSourceLanguage)
+        ret = ccall(("gtk_source_language_get_id", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function get_metadata(instance::GtkSourceLanguage, _name::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_language_get_metadata", libgtksourceview), Cstring, (Ptr{GObject}, Cstring), instance, _name)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function get_mime_types(instance::GtkSourceLanguage)
+        ret = ccall(("gtk_source_language_get_mime_types", libgtksourceview), Ptr{Cstring}, (Ptr{GObject},), instance)
+        ret2 = begin
+                _len = length_zt(ret)
+                arrtemp = bytestring.(unsafe_wrap(Vector{Cstring}, ret, _len))
+                GLib.g_strfreev(ret)
+                arrtemp
+            end
+        ret2
+    end
+    function get_name(instance::GtkSourceLanguage)
+        ret = ccall(("gtk_source_language_get_name", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function get_section(instance::GtkSourceLanguage)
+        ret = ccall(("gtk_source_language_get_section", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function get_style_fallback(instance::GtkSourceLanguage, _style_id::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_language_get_style_fallback", libgtksourceview), Cstring, (Ptr{GObject}, Cstring), instance, _style_id)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function get_style_ids(instance::GtkSourceLanguage)
+        ret = ccall(("gtk_source_language_get_style_ids", libgtksourceview), Ptr{Cstring}, (Ptr{GObject},), instance)
+        ret2 = begin
+                _len = length_zt(ret)
+                arrtemp = bytestring.(unsafe_wrap(Vector{Cstring}, ret, _len))
+                GLib.g_strfreev(ret)
+                arrtemp
+            end
+        ret2
+    end
+    function get_style_name(instance::GtkSourceLanguage, _style_id::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_language_get_style_name", libgtksourceview), Cstring, (Ptr{GObject}, Cstring), instance, _style_id)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function LanguageManager_new()
+        ret = ccall(("gtk_source_language_manager_new", libgtksourceview), Ptr{GObject}, ())
+        ret2 = GtkSourceLanguageManagerLeaf(ret, true)
+        ret2
+    end
+    function append_search_path(instance::GtkSourceLanguageManager, _path::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_language_manager_append_search_path", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _path)
+        nothing
+    end
+    function get_language(instance::GtkSourceLanguageManager, _id::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_language_manager_get_language", libgtksourceview), Ptr{GObject}, (Ptr{GObject}, Cstring), instance, _id)
+        ret2 = convert_if_not_null(GtkSourceLanguage, ret, false)
+        ret2
+    end
+    function get_language_ids(instance::GtkSourceLanguageManager)
+        ret = ccall(("gtk_source_language_manager_get_language_ids", libgtksourceview), Ptr{Cstring}, (Ptr{GObject},), instance)
+        ret2 = begin
+                _len = length_zt(ret)
+                arrtemp = bytestring.(unsafe_wrap(Vector{Cstring}, ret, _len))
+                arrtemp
+            end
+        ret2
+    end
+    function get_search_path(instance::GtkSourceLanguageManager)
+        ret = ccall(("gtk_source_language_manager_get_search_path", libgtksourceview), Ptr{Cstring}, (Ptr{GObject},), instance)
+        ret2 = begin
+                _len = length_zt(ret)
+                arrtemp = bytestring.(unsafe_wrap(Vector{Cstring}, ret, _len))
+                arrtemp
+            end
+        ret2
+    end
+    function guess_language(instance::GtkSourceLanguageManager, _filename::Maybe(Union{AbstractString, Symbol}), _content_type::Maybe(Union{AbstractString, Symbol}))
+        _filename_maybe = nothing_to_null(_filename)
+        _content_type_maybe = nothing_to_null(_content_type)
+        ret = ccall(("gtk_source_language_manager_guess_language", libgtksourceview), Ptr{GObject}, (Ptr{GObject}, Cstring, Cstring), instance, _filename_maybe, _content_type_maybe)
+        ret2 = convert_if_not_null(GtkSourceLanguage, ret, false)
+        ret2
+    end
+    function prepend_search_path(instance::GtkSourceLanguageManager, _path::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_language_manager_prepend_search_path", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _path)
+        nothing
+    end
+    function set_search_path(instance::GtkSourceLanguageManager, _dirs)
+        _dirs_maybe = nothing_to_null(_dirs)
+        ret = ccall(("gtk_source_language_manager_set_search_path", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{Cstring}), instance, _dirs_maybe)
+        nothing
+    end
+    function Map_new()
+        ret = ccall(("gtk_source_map_new", libgtksourceview), Ptr{GObject}, ())
+        ret2 = GtkSourceMapLeaf(ret, false)
+        ret2
+    end
+    function get_view(instance::GtkSourceMap)
+        ret = ccall(("gtk_source_map_get_view", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert_if_not_null(GtkSourceView, ret, false)
+        ret2
+    end
+    function set_view(instance::GtkSourceMap, _view::GtkSourceView)
+        ret = ccall(("gtk_source_map_set_view", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _view)
+        nothing
+    end
+    function Mark_new(_name::Maybe(Union{AbstractString, Symbol}), _category::Union{AbstractString, Symbol})
+        _name_maybe = nothing_to_null(_name)
+        ret = ccall(("gtk_source_mark_new", libgtksourceview), Ptr{GObject}, (Cstring, Cstring), _name_maybe, _category)
+        ret2 = GtkSourceMarkLeaf(ret, true)
+        ret2
+    end
+    function get_category(instance::GtkSourceMark)
+        ret = ccall(("gtk_source_mark_get_category", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function next(instance::GtkSourceMark, _category::Maybe(Union{AbstractString, Symbol}))
+        _category_maybe = nothing_to_null(_category)
+        ret = ccall(("gtk_source_mark_next", libgtksourceview), Ptr{GObject}, (Ptr{GObject}, Cstring), instance, _category_maybe)
+        ret2 = convert_if_not_null(GtkSourceMark, ret, false)
+        ret2
+    end
+    function prev(instance::GtkSourceMark, _category::Maybe(Union{AbstractString, Symbol}))
+        _category_maybe = nothing_to_null(_category)
+        ret = ccall(("gtk_source_mark_prev", libgtksourceview), Ptr{GObject}, (Ptr{GObject}, Cstring), instance, _category_maybe)
+        ret2 = convert_if_not_null(GtkSourceMark, ret, false)
+        ret2
+    end
+    function MarkAttributes_new()
+        ret = ccall(("gtk_source_mark_attributes_new", libgtksourceview), Ptr{GObject}, ())
+        ret2 = GtkSourceMarkAttributesLeaf(ret, true)
+        ret2
+    end
+    function get_background(instance::GtkSourceMarkAttributes)
+        m_background = Ref{_GdkRGBA}()
+        ret = ccall(("gtk_source_mark_attributes_get_background", libgtksourceview), Cint, (Ptr{GObject}, Ptr{_GdkRGBA}), instance, m_background)
+        ret2 = convert(Bool, ret)
+        _background = m_background[]
+        (ret2, _background)
+    end
+    function get_gicon(instance::GtkSourceMarkAttributes)
+        ret = ccall(("gtk_source_mark_attributes_get_gicon", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = begin
+                leaftype = GLib.find_leaf_type(ret)
+                convert(leaftype, ret, false)
+            end
+        ret2
+    end
+    function get_icon_name(instance::GtkSourceMarkAttributes)
+        ret = ccall(("gtk_source_mark_attributes_get_icon_name", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function get_pixbuf(instance::GtkSourceMarkAttributes)
+        ret = ccall(("gtk_source_mark_attributes_get_pixbuf", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GdkPixbuf, ret, false)
+        ret2
+    end
+    function get_tooltip_markup(instance::GtkSourceMarkAttributes, _mark::GtkSourceMark)
+        ret = ccall(("gtk_source_mark_attributes_get_tooltip_markup", libgtksourceview), Cstring, (Ptr{GObject}, Ptr{GObject}), instance, _mark)
+        ret2 = string_or_nothing(ret, true)
+        ret2
+    end
+    function get_tooltip_text(instance::GtkSourceMarkAttributes, _mark::GtkSourceMark)
+        ret = ccall(("gtk_source_mark_attributes_get_tooltip_text", libgtksourceview), Cstring, (Ptr{GObject}, Ptr{GObject}), instance, _mark)
+        ret2 = string_or_nothing(ret, true)
+        ret2
+    end
+    function render_icon(instance::GtkSourceMarkAttributes, _widget::GtkWidget, _size::Integer)
+        ret = ccall(("gtk_source_mark_attributes_render_icon", libgtksourceview), Ptr{GObject}, (Ptr{GObject}, Ptr{GObject}, Int32), instance, _widget, _size)
+        ret2 = begin
+                leaftype = GLib.find_leaf_type(ret)
+                convert(leaftype, ret, false)
+            end
+        ret2
+    end
+    function set_background(instance::GtkSourceMarkAttributes, _background::Union{GdkRGBA, Ref{_GdkRGBA}})
+        ret = ccall(("gtk_source_mark_attributes_set_background", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{_GdkRGBA}), instance, _background)
+        nothing
+    end
+    function set_gicon(instance::GtkSourceMarkAttributes, _gicon::GIcon)
+        ret = ccall(("gtk_source_mark_attributes_set_gicon", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _gicon)
+        nothing
+    end
+    function set_icon_name(instance::GtkSourceMarkAttributes, _icon_name::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_mark_attributes_set_icon_name", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _icon_name)
+        nothing
+    end
+    function set_pixbuf(instance::GtkSourceMarkAttributes, _pixbuf::GdkPixbuf)
+        ret = ccall(("gtk_source_mark_attributes_set_pixbuf", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _pixbuf)
+        nothing
+    end
+    function PrintCompositor_new(_buffer::GtkSourceBuffer)
+        ret = ccall(("gtk_source_print_compositor_new", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), _buffer)
+        ret2 = GtkSourcePrintCompositorLeaf(ret, true)
+        ret2
+    end
+    function PrintCompositor_new_from_view(_view::GtkSourceView)
+        ret = ccall(("gtk_source_print_compositor_new_from_view", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), _view)
+        ret2 = GtkSourcePrintCompositorLeaf(ret, true)
+        ret2
+    end
+    function draw_page(instance::GtkSourcePrintCompositor, _context::GtkPrintContext, _page_nr::Integer)
+        ret = ccall(("gtk_source_print_compositor_draw_page", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}, Int32), instance, _context, _page_nr)
+        nothing
+    end
+    function get_body_font_name(instance::GtkSourcePrintCompositor)
+        ret = ccall(("gtk_source_print_compositor_get_body_font_name", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, true)
+        ret2
+    end
+    function get_bottom_margin(instance::GtkSourcePrintCompositor, _unit)
+        ret = ccall(("gtk_source_print_compositor_get_bottom_margin", libgtksourceview), Float64, (Ptr{GObject}, UInt32), instance, _unit)
+        ret
+    end
+    function get_buffer(instance::GtkSourcePrintCompositor)
+        ret = ccall(("gtk_source_print_compositor_get_buffer", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceBuffer, ret, false)
+        ret2
+    end
+    function get_footer_font_name(instance::GtkSourcePrintCompositor)
+        ret = ccall(("gtk_source_print_compositor_get_footer_font_name", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, true)
+        ret2
+    end
+    function get_header_font_name(instance::GtkSourcePrintCompositor)
+        ret = ccall(("gtk_source_print_compositor_get_header_font_name", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, true)
+        ret2
+    end
+    function get_highlight_syntax(instance::GtkSourcePrintCompositor)
+        ret = ccall(("gtk_source_print_compositor_get_highlight_syntax", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_left_margin(instance::GtkSourcePrintCompositor, _unit)
+        ret = ccall(("gtk_source_print_compositor_get_left_margin", libgtksourceview), Float64, (Ptr{GObject}, UInt32), instance, _unit)
+        ret
+    end
+    function get_line_numbers_font_name(instance::GtkSourcePrintCompositor)
+        ret = ccall(("gtk_source_print_compositor_get_line_numbers_font_name", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, true)
+        ret2
+    end
+    function get_n_pages(instance::GtkSourcePrintCompositor)
+        ret = ccall(("gtk_source_print_compositor_get_n_pages", libgtksourceview), Int32, (Ptr{GObject},), instance)
+        ret
+    end
+    function get_pagination_progress(instance::GtkSourcePrintCompositor)
+        ret = ccall(("gtk_source_print_compositor_get_pagination_progress", libgtksourceview), Float64, (Ptr{GObject},), instance)
+        ret
+    end
+    function get_print_footer(instance::GtkSourcePrintCompositor)
+        ret = ccall(("gtk_source_print_compositor_get_print_footer", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_print_header(instance::GtkSourcePrintCompositor)
+        ret = ccall(("gtk_source_print_compositor_get_print_header", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_print_line_numbers(instance::GtkSourcePrintCompositor)
+        ret = ccall(("gtk_source_print_compositor_get_print_line_numbers", libgtksourceview), UInt32, (Ptr{GObject},), instance)
+        ret
+    end
+    function get_right_margin(instance::GtkSourcePrintCompositor, _unit)
+        ret = ccall(("gtk_source_print_compositor_get_right_margin", libgtksourceview), Float64, (Ptr{GObject}, UInt32), instance, _unit)
+        ret
+    end
+    function get_tab_width(instance::GtkSourcePrintCompositor)
+        ret = ccall(("gtk_source_print_compositor_get_tab_width", libgtksourceview), UInt32, (Ptr{GObject},), instance)
+        ret
+    end
+    function get_top_margin(instance::GtkSourcePrintCompositor, _unit)
+        ret = ccall(("gtk_source_print_compositor_get_top_margin", libgtksourceview), Float64, (Ptr{GObject}, UInt32), instance, _unit)
+        ret
+    end
+    function get_wrap_mode(instance::GtkSourcePrintCompositor)
+        ret = ccall(("gtk_source_print_compositor_get_wrap_mode", libgtksourceview), UInt32, (Ptr{GObject},), instance)
+        ret2 = WrapMode(ret)
+        ret2
+    end
+    function ignore_tag(instance::GtkSourcePrintCompositor, _tag::GtkTextTag)
+        ret = ccall(("gtk_source_print_compositor_ignore_tag", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _tag)
+        nothing
+    end
+    function paginate(instance::GtkSourcePrintCompositor, _context::GtkPrintContext)
+        ret = ccall(("gtk_source_print_compositor_paginate", libgtksourceview), Cint, (Ptr{GObject}, Ptr{GObject}), instance, _context)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function set_body_font_name(instance::GtkSourcePrintCompositor, _font_name::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_print_compositor_set_body_font_name", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _font_name)
+        nothing
+    end
+    function set_bottom_margin(instance::GtkSourcePrintCompositor, _margin::Real, _unit)
+        ret = ccall(("gtk_source_print_compositor_set_bottom_margin", libgtksourceview), Nothing, (Ptr{GObject}, Float64, UInt32), instance, _margin, _unit)
+        nothing
+    end
+    function set_footer_font_name(instance::GtkSourcePrintCompositor, _font_name::Maybe(Union{AbstractString, Symbol}))
+        _font_name_maybe = nothing_to_null(_font_name)
+        ret = ccall(("gtk_source_print_compositor_set_footer_font_name", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _font_name_maybe)
+        nothing
+    end
+    function set_footer_format(instance::GtkSourcePrintCompositor, _separator::Bool, _left::Maybe(Union{AbstractString, Symbol}), _center::Maybe(Union{AbstractString, Symbol}), _right::Maybe(Union{AbstractString, Symbol}))
+        _left_maybe = nothing_to_null(_left)
+        _center_maybe = nothing_to_null(_center)
+        _right_maybe = nothing_to_null(_right)
+        ret = ccall(("gtk_source_print_compositor_set_footer_format", libgtksourceview), Nothing, (Ptr{GObject}, Cint, Cstring, Cstring, Cstring), instance, _separator, _left_maybe, _center_maybe, _right_maybe)
+        nothing
+    end
+    function set_header_font_name(instance::GtkSourcePrintCompositor, _font_name::Maybe(Union{AbstractString, Symbol}))
+        _font_name_maybe = nothing_to_null(_font_name)
+        ret = ccall(("gtk_source_print_compositor_set_header_font_name", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _font_name_maybe)
+        nothing
+    end
+    function set_header_format(instance::GtkSourcePrintCompositor, _separator::Bool, _left::Maybe(Union{AbstractString, Symbol}), _center::Maybe(Union{AbstractString, Symbol}), _right::Maybe(Union{AbstractString, Symbol}))
+        _left_maybe = nothing_to_null(_left)
+        _center_maybe = nothing_to_null(_center)
+        _right_maybe = nothing_to_null(_right)
+        ret = ccall(("gtk_source_print_compositor_set_header_format", libgtksourceview), Nothing, (Ptr{GObject}, Cint, Cstring, Cstring, Cstring), instance, _separator, _left_maybe, _center_maybe, _right_maybe)
+        nothing
+    end
+    function set_highlight_syntax(instance::GtkSourcePrintCompositor, _highlight::Bool)
+        ret = ccall(("gtk_source_print_compositor_set_highlight_syntax", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _highlight)
+        nothing
+    end
+    function set_left_margin(instance::GtkSourcePrintCompositor, _margin::Real, _unit)
+        ret = ccall(("gtk_source_print_compositor_set_left_margin", libgtksourceview), Nothing, (Ptr{GObject}, Float64, UInt32), instance, _margin, _unit)
+        nothing
+    end
+    function set_line_numbers_font_name(instance::GtkSourcePrintCompositor, _font_name::Maybe(Union{AbstractString, Symbol}))
+        _font_name_maybe = nothing_to_null(_font_name)
+        ret = ccall(("gtk_source_print_compositor_set_line_numbers_font_name", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _font_name_maybe)
+        nothing
+    end
+    function set_print_footer(instance::GtkSourcePrintCompositor, _print::Bool)
+        ret = ccall(("gtk_source_print_compositor_set_print_footer", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _print)
+        nothing
+    end
+    function set_print_header(instance::GtkSourcePrintCompositor, _print::Bool)
+        ret = ccall(("gtk_source_print_compositor_set_print_header", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _print)
+        nothing
+    end
+    function set_print_line_numbers(instance::GtkSourcePrintCompositor, _interval::Integer)
+        ret = ccall(("gtk_source_print_compositor_set_print_line_numbers", libgtksourceview), Nothing, (Ptr{GObject}, UInt32), instance, _interval)
+        nothing
+    end
+    function set_right_margin(instance::GtkSourcePrintCompositor, _margin::Real, _unit)
+        ret = ccall(("gtk_source_print_compositor_set_right_margin", libgtksourceview), Nothing, (Ptr{GObject}, Float64, UInt32), instance, _margin, _unit)
+        nothing
+    end
+    function set_tab_width(instance::GtkSourcePrintCompositor, _width::Integer)
+        ret = ccall(("gtk_source_print_compositor_set_tab_width", libgtksourceview), Nothing, (Ptr{GObject}, UInt32), instance, _width)
+        nothing
+    end
+    function set_top_margin(instance::GtkSourcePrintCompositor, _margin::Real, _unit)
+        ret = ccall(("gtk_source_print_compositor_set_top_margin", libgtksourceview), Nothing, (Ptr{GObject}, Float64, UInt32), instance, _margin, _unit)
+        nothing
+    end
+    function set_wrap_mode(instance::GtkSourcePrintCompositor, _wrap_mode)
+        ret = ccall(("gtk_source_print_compositor_set_wrap_mode", libgtksourceview), Nothing, (Ptr{GObject}, UInt32), instance, _wrap_mode)
+        nothing
+    end
+    function Region_new(_buffer::GtkTextBuffer)
+        ret = ccall(("gtk_source_region_new", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), _buffer)
+        ret2 = GtkSourceRegionLeaf(ret, true)
+        ret2
+    end
+    function add_region(instance::GtkSourceRegion, _region_to_add::Maybe(GtkSourceRegion))
+        _region_to_add_maybe = nothing_to_null(_region_to_add)
+        ret = ccall(("gtk_source_region_add_region", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _region_to_add_maybe)
+        nothing
+    end
+    function add_subregion(instance::GtkSourceRegion, __start::Union{GtkTextIter, Ref{_GtkTextIter}}, __end::Union{GtkTextIter, Ref{_GtkTextIter}})
+        ret = ccall(("gtk_source_region_add_subregion", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{_GtkTextIter}, Ptr{_GtkTextIter}), instance, __start, __end)
+        nothing
+    end
+    function get_bounds(instance::GtkSourceRegion)
+        m_start = Ref{_GtkTextIter}()
+        m_end = Ref{_GtkTextIter}()
+        ret = ccall(("gtk_source_region_get_bounds", libgtksourceview), Cint, (Ptr{GObject}, Ptr{_GtkTextIter}, Ptr{_GtkTextIter}), instance, m_start, m_end)
+        ret2 = convert(Bool, ret)
+        _start = m_start[]
+        _end = m_end[]
+        (ret2, _start, _end)
+    end
+    function get_buffer(instance::GtkSourceRegion)
+        ret = ccall(("gtk_source_region_get_buffer", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert_if_not_null(GtkTextBuffer, ret, false)
+        ret2
+    end
+    function get_start_region_iter(instance::GtkSourceRegion)
+        m_iter = Ref{_GtkSourceRegionIter}()
+        ret = ccall(("gtk_source_region_get_start_region_iter", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{_GtkSourceRegionIter}), instance, m_iter)
+        _iter = m_iter[]
+        _iter = convert(_GtkSourceRegionIter, _iter)
+        _iter
+    end
+    function intersect_region(instance::GtkSourceRegion, _region2::Maybe(GtkSourceRegion))
+        _region2_maybe = nothing_to_null(_region2)
+        ret = ccall(("gtk_source_region_intersect_region", libgtksourceview), Ptr{GObject}, (Ptr{GObject}, Ptr{GObject}), instance, _region2_maybe)
+        ret2 = convert_if_not_null(GtkSourceRegion, ret, true)
+        ret2
+    end
+    function intersect_subregion(instance::GtkSourceRegion, __start::Union{GtkTextIter, Ref{_GtkTextIter}}, __end::Union{GtkTextIter, Ref{_GtkTextIter}})
+        ret = ccall(("gtk_source_region_intersect_subregion", libgtksourceview), Ptr{GObject}, (Ptr{GObject}, Ptr{_GtkTextIter}, Ptr{_GtkTextIter}), instance, __start, __end)
+        ret2 = convert_if_not_null(GtkSourceRegion, ret, true)
+        ret2
+    end
+    function is_empty(instance::GtkSourceRegion)
+        ret = ccall(("gtk_source_region_is_empty", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function subtract_region(instance::GtkSourceRegion, _region_to_subtract::Maybe(GtkSourceRegion))
+        _region_to_subtract_maybe = nothing_to_null(_region_to_subtract)
+        ret = ccall(("gtk_source_region_subtract_region", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _region_to_subtract_maybe)
+        nothing
+    end
+    function subtract_subregion(instance::GtkSourceRegion, __start::Union{GtkTextIter, Ref{_GtkTextIter}}, __end::Union{GtkTextIter, Ref{_GtkTextIter}})
+        ret = ccall(("gtk_source_region_subtract_subregion", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{_GtkTextIter}, Ptr{_GtkTextIter}), instance, __start, __end)
+        nothing
+    end
+    function to_string(instance::GtkSourceRegion)
+        ret = ccall(("gtk_source_region_to_string", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, true)
+        ret2
+    end
+    function SearchContext_new(_buffer::GtkSourceBuffer, _settings::Maybe(GtkSourceSearchSettings))
+        _settings_maybe = nothing_to_null(_settings)
+        ret = ccall(("gtk_source_search_context_new", libgtksourceview), Ptr{GObject}, (Ptr{GObject}, Ptr{GObject}), _buffer, _settings_maybe)
+        ret2 = GtkSourceSearchContextLeaf(ret, true)
+        ret2
+    end
+    function backward(instance::GtkSourceSearchContext, _iter::Union{GtkTextIter, Ref{_GtkTextIter}})
+        m_match_start = Ref{_GtkTextIter}()
+        m_match_end = Ref{_GtkTextIter}()
+        m_has_wrapped_around = Ref{Cint}()
+        ret = ccall(("gtk_source_search_context_backward", libgtksourceview), Cint, (Ptr{GObject}, Ptr{_GtkTextIter}, Ptr{_GtkTextIter}, Ptr{_GtkTextIter}, Ptr{Cint}), instance, _iter, m_match_start, m_match_end, m_has_wrapped_around)
+        ret2 = convert(Bool, ret)
+        _match_start = m_match_start[]
+        _match_end = m_match_end[]
+        _has_wrapped_around = m_has_wrapped_around[]
+        _has_wrapped_around = convert(Bool, _has_wrapped_around)
+        (ret2, _match_start, _match_end, _has_wrapped_around)
+    end
+    function backward_async(instance::GtkSourceSearchContext, _iter::Union{GtkTextIter, Ref{_GtkTextIter}}, _cancellable::Maybe(GCancellable), _callback::Maybe(Function))
+        _cancellable_maybe = nothing_to_null(_cancellable)
+        if _callback === nothing
+            _callback_cfunc = C_NULL
+            _callback_closure = C_NULL
+        else
+            _callback_cfunc = @cfunction(GAsyncReadyCallback, Nothing, (Ptr{GObject}, Ptr{GObject}, Ref{Function}))
+            _callback_closure = GLib.gc_ref(_callback)
+        end
+        ret = ccall(("gtk_source_search_context_backward_async", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{_GtkTextIter}, Ptr{GObject}, Ptr{Cvoid}, Ptr{Nothing}), instance, _iter, _cancellable_maybe, _callback_cfunc, _callback_closure)
+        nothing
+    end
+    function backward_finish(instance::GtkSourceSearchContext, _result::GAsyncResult)
+        m_match_start = Ref{_GtkTextIter}()
+        m_match_end = Ref{_GtkTextIter}()
+        m_has_wrapped_around = Ref{Cint}()
+        err = err_buf()
+        ret = ccall(("gtk_source_search_context_backward_finish", libgtksourceview), Cint, (Ptr{GObject}, Ptr{GObject}, Ptr{_GtkTextIter}, Ptr{_GtkTextIter}, Ptr{Cint}, Ptr{Ptr{GError}}), instance, _result, m_match_start, m_match_end, m_has_wrapped_around, err)
+        check_err(err)
+        ret2 = convert(Bool, ret)
+        _match_start = m_match_start[]
+        _match_end = m_match_end[]
+        _has_wrapped_around = m_has_wrapped_around[]
+        _has_wrapped_around = convert(Bool, _has_wrapped_around)
+        (ret2, _match_start, _match_end, _has_wrapped_around)
+    end
+    function forward(instance::GtkSourceSearchContext, _iter::Union{GtkTextIter, Ref{_GtkTextIter}})
+        m_match_start = Ref{_GtkTextIter}()
+        m_match_end = Ref{_GtkTextIter}()
+        m_has_wrapped_around = Ref{Cint}()
+        ret = ccall(("gtk_source_search_context_forward", libgtksourceview), Cint, (Ptr{GObject}, Ptr{_GtkTextIter}, Ptr{_GtkTextIter}, Ptr{_GtkTextIter}, Ptr{Cint}), instance, _iter, m_match_start, m_match_end, m_has_wrapped_around)
+        ret2 = convert(Bool, ret)
+        _match_start = m_match_start[]
+        _match_end = m_match_end[]
+        _has_wrapped_around = m_has_wrapped_around[]
+        _has_wrapped_around = convert(Bool, _has_wrapped_around)
+        (ret2, _match_start, _match_end, _has_wrapped_around)
+    end
+    function forward_async(instance::GtkSourceSearchContext, _iter::Union{GtkTextIter, Ref{_GtkTextIter}}, _cancellable::Maybe(GCancellable), _callback::Maybe(Function))
+        _cancellable_maybe = nothing_to_null(_cancellable)
+        if _callback === nothing
+            _callback_cfunc = C_NULL
+            _callback_closure = C_NULL
+        else
+            _callback_cfunc = @cfunction(GAsyncReadyCallback, Nothing, (Ptr{GObject}, Ptr{GObject}, Ref{Function}))
+            _callback_closure = GLib.gc_ref(_callback)
+        end
+        ret = ccall(("gtk_source_search_context_forward_async", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{_GtkTextIter}, Ptr{GObject}, Ptr{Cvoid}, Ptr{Nothing}), instance, _iter, _cancellable_maybe, _callback_cfunc, _callback_closure)
+        nothing
+    end
+    function forward_finish(instance::GtkSourceSearchContext, _result::GAsyncResult)
+        m_match_start = Ref{_GtkTextIter}()
+        m_match_end = Ref{_GtkTextIter}()
+        m_has_wrapped_around = Ref{Cint}()
+        err = err_buf()
+        ret = ccall(("gtk_source_search_context_forward_finish", libgtksourceview), Cint, (Ptr{GObject}, Ptr{GObject}, Ptr{_GtkTextIter}, Ptr{_GtkTextIter}, Ptr{Cint}, Ptr{Ptr{GError}}), instance, _result, m_match_start, m_match_end, m_has_wrapped_around, err)
+        check_err(err)
+        ret2 = convert(Bool, ret)
+        _match_start = m_match_start[]
+        _match_end = m_match_end[]
+        _has_wrapped_around = m_has_wrapped_around[]
+        _has_wrapped_around = convert(Bool, _has_wrapped_around)
+        (ret2, _match_start, _match_end, _has_wrapped_around)
+    end
+    function get_buffer(instance::GtkSourceSearchContext)
+        ret = ccall(("gtk_source_search_context_get_buffer", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceBuffer, ret, false)
+        ret2
+    end
+    function get_highlight(instance::GtkSourceSearchContext)
+        ret = ccall(("gtk_source_search_context_get_highlight", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_match_style(instance::GtkSourceSearchContext)
+        ret = ccall(("gtk_source_search_context_get_match_style", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceStyle, ret, false)
+        ret2
+    end
+    function get_occurrence_position(instance::GtkSourceSearchContext, _match_start::Union{GtkTextIter, Ref{_GtkTextIter}}, _match_end::Union{GtkTextIter, Ref{_GtkTextIter}})
+        ret = ccall(("gtk_source_search_context_get_occurrence_position", libgtksourceview), Int32, (Ptr{GObject}, Ptr{_GtkTextIter}, Ptr{_GtkTextIter}), instance, _match_start, _match_end)
+        ret
+    end
+    function get_occurrences_count(instance::GtkSourceSearchContext)
+        ret = ccall(("gtk_source_search_context_get_occurrences_count", libgtksourceview), Int32, (Ptr{GObject},), instance)
+        ret
+    end
+    function get_regex_error(instance::GtkSourceSearchContext)
+        ret = ccall(("gtk_source_search_context_get_regex_error", libgtksourceview), Ptr{GError}, (Ptr{GObject},), instance)
+        ret
+    end
+    function get_settings(instance::GtkSourceSearchContext)
+        ret = ccall(("gtk_source_search_context_get_settings", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceSearchSettings, ret, false)
+        ret2
+    end
+    function replace(instance::GtkSourceSearchContext, _match_start::Union{GtkTextIter, Ref{_GtkTextIter}}, _match_end::Union{GtkTextIter, Ref{_GtkTextIter}}, _replace::Union{AbstractString, Symbol}, _replace_length::Integer)
+        err = err_buf()
+        ret = ccall(("gtk_source_search_context_replace", libgtksourceview), Cint, (Ptr{GObject}, Ptr{_GtkTextIter}, Ptr{_GtkTextIter}, Cstring, Int32, Ptr{Ptr{GError}}), instance, _match_start, _match_end, _replace, _replace_length, err)
+        check_err(err)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function replace_all(instance::GtkSourceSearchContext, _replace::Union{AbstractString, Symbol}, _replace_length::Integer)
+        err = err_buf()
+        ret = ccall(("gtk_source_search_context_replace_all", libgtksourceview), UInt32, (Ptr{GObject}, Cstring, Int32, Ptr{Ptr{GError}}), instance, _replace, _replace_length, err)
+        check_err(err)
+        ret
+    end
+    function set_highlight(instance::GtkSourceSearchContext, _highlight::Bool)
+        ret = ccall(("gtk_source_search_context_set_highlight", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _highlight)
+        nothing
+    end
+    function set_match_style(instance::GtkSourceSearchContext, _match_style::Maybe(GtkSourceStyle))
+        _match_style_maybe = nothing_to_null(_match_style)
+        ret = ccall(("gtk_source_search_context_set_match_style", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _match_style_maybe)
+        nothing
+    end
+    function SearchSettings_new()
+        ret = ccall(("gtk_source_search_settings_new", libgtksourceview), Ptr{GObject}, ())
+        ret2 = GtkSourceSearchSettingsLeaf(ret, true)
+        ret2
+    end
+    function get_at_word_boundaries(instance::GtkSourceSearchSettings)
+        ret = ccall(("gtk_source_search_settings_get_at_word_boundaries", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_case_sensitive(instance::GtkSourceSearchSettings)
+        ret = ccall(("gtk_source_search_settings_get_case_sensitive", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_regex_enabled(instance::GtkSourceSearchSettings)
+        ret = ccall(("gtk_source_search_settings_get_regex_enabled", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_search_text(instance::GtkSourceSearchSettings)
+        ret = ccall(("gtk_source_search_settings_get_search_text", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function get_wrap_around(instance::GtkSourceSearchSettings)
+        ret = ccall(("gtk_source_search_settings_get_wrap_around", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function set_at_word_boundaries(instance::GtkSourceSearchSettings, _at_word_boundaries::Bool)
+        ret = ccall(("gtk_source_search_settings_set_at_word_boundaries", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _at_word_boundaries)
+        nothing
+    end
+    function set_case_sensitive(instance::GtkSourceSearchSettings, _case_sensitive::Bool)
+        ret = ccall(("gtk_source_search_settings_set_case_sensitive", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _case_sensitive)
+        nothing
+    end
+    function set_regex_enabled(instance::GtkSourceSearchSettings, _regex_enabled::Bool)
+        ret = ccall(("gtk_source_search_settings_set_regex_enabled", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _regex_enabled)
+        nothing
+    end
+    function set_search_text(instance::GtkSourceSearchSettings, _search_text::Maybe(Union{AbstractString, Symbol}))
+        _search_text_maybe = nothing_to_null(_search_text)
+        ret = ccall(("gtk_source_search_settings_set_search_text", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _search_text_maybe)
+        nothing
+    end
+    function set_wrap_around(instance::GtkSourceSearchSettings, _wrap_around::Bool)
+        ret = ccall(("gtk_source_search_settings_set_wrap_around", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _wrap_around)
+        nothing
+    end
+    function Snippet_new(_trigger::Maybe(Union{AbstractString, Symbol}), _language_id::Maybe(Union{AbstractString, Symbol}))
+        _trigger_maybe = nothing_to_null(_trigger)
+        _language_id_maybe = nothing_to_null(_language_id)
+        ret = ccall(("gtk_source_snippet_new", libgtksourceview), Ptr{GObject}, (Cstring, Cstring), _trigger_maybe, _language_id_maybe)
+        ret2 = GtkSourceSnippetLeaf(ret, true)
+        ret2
+    end
+    function Snippet_new_parsed(_text::Union{AbstractString, Symbol})
+        err = err_buf()
+        ret = ccall(("gtk_source_snippet_new_parsed", libgtksourceview), Ptr{GObject}, (Cstring, Ptr{Ptr{GError}}), _text, err)
+        check_err(err)
+        ret2 = GtkSourceSnippetLeaf(ret, true)
+        ret2
+    end
+    function add_chunk(instance::GtkSourceSnippet, _chunk::GtkSourceSnippetChunk)
+        ret = ccall(("gtk_source_snippet_add_chunk", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _chunk)
+        nothing
+    end
+    function copy(instance::GtkSourceSnippet)
+        ret = ccall(("gtk_source_snippet_copy", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceSnippet, ret, true)
+        ret2
+    end
+    function get_context(instance::GtkSourceSnippet)
+        ret = ccall(("gtk_source_snippet_get_context", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert_if_not_null(GtkSourceSnippetContext, ret, false)
+        ret2
+    end
+    function get_description(instance::GtkSourceSnippet)
+        ret = ccall(("gtk_source_snippet_get_description", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function get_focus_position(instance::GtkSourceSnippet)
+        ret = ccall(("gtk_source_snippet_get_focus_position", libgtksourceview), Int32, (Ptr{GObject},), instance)
+        ret
+    end
+    function get_language_id(instance::GtkSourceSnippet)
+        ret = ccall(("gtk_source_snippet_get_language_id", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function get_n_chunks(instance::GtkSourceSnippet)
+        ret = ccall(("gtk_source_snippet_get_n_chunks", libgtksourceview), UInt32, (Ptr{GObject},), instance)
+        ret
+    end
+    function get_name(instance::GtkSourceSnippet)
+        ret = ccall(("gtk_source_snippet_get_name", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function get_nth_chunk(instance::GtkSourceSnippet, _nth::Integer)
+        ret = ccall(("gtk_source_snippet_get_nth_chunk", libgtksourceview), Ptr{GObject}, (Ptr{GObject}, UInt32), instance, _nth)
+        ret2 = convert(GtkSourceSnippetChunk, ret, false)
+        ret2
+    end
+    function get_trigger(instance::GtkSourceSnippet)
+        ret = ccall(("gtk_source_snippet_get_trigger", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function set_description(instance::GtkSourceSnippet, _description::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_snippet_set_description", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _description)
+        nothing
+    end
+    function set_language_id(instance::GtkSourceSnippet, _language_id::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_snippet_set_language_id", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _language_id)
+        nothing
+    end
+    function set_name(instance::GtkSourceSnippet, _name::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_snippet_set_name", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _name)
+        nothing
+    end
+    function set_trigger(instance::GtkSourceSnippet, _trigger::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_snippet_set_trigger", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _trigger)
+        nothing
+    end
+    function SnippetChunk_new()
+        ret = ccall(("gtk_source_snippet_chunk_new", libgtksourceview), Ptr{GObject}, ())
+        ret2 = GtkSourceSnippetChunkLeaf(ret, false)
+        ret2
+    end
+    function copy(instance::GtkSourceSnippetChunk)
+        ret = ccall(("gtk_source_snippet_chunk_copy", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceSnippetChunk, ret, true)
+        ret2
+    end
+    function get_context(instance::GtkSourceSnippetChunk)
+        ret = ccall(("gtk_source_snippet_chunk_get_context", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceSnippetContext, ret, false)
+        ret2
+    end
+    function get_focus_position(instance::GtkSourceSnippetChunk)
+        ret = ccall(("gtk_source_snippet_chunk_get_focus_position", libgtksourceview), Int32, (Ptr{GObject},), instance)
+        ret
+    end
+    function get_spec(instance::GtkSourceSnippetChunk)
+        ret = ccall(("gtk_source_snippet_chunk_get_spec", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function get_text(instance::GtkSourceSnippetChunk)
+        ret = ccall(("gtk_source_snippet_chunk_get_text", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function get_text_set(instance::GtkSourceSnippetChunk)
+        ret = ccall(("gtk_source_snippet_chunk_get_text_set", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_tooltip_text(instance::GtkSourceSnippetChunk)
+        ret = ccall(("gtk_source_snippet_chunk_get_tooltip_text", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function set_context(instance::GtkSourceSnippetChunk, _context::GtkSourceSnippetContext)
+        ret = ccall(("gtk_source_snippet_chunk_set_context", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _context)
+        nothing
+    end
+    function set_focus_position(instance::GtkSourceSnippetChunk, _focus_position::Integer)
+        ret = ccall(("gtk_source_snippet_chunk_set_focus_position", libgtksourceview), Nothing, (Ptr{GObject}, Int32), instance, _focus_position)
+        nothing
+    end
+    function set_spec(instance::GtkSourceSnippetChunk, _spec::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_snippet_chunk_set_spec", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _spec)
+        nothing
+    end
+    function set_text(instance::GtkSourceSnippetChunk, _text::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_snippet_chunk_set_text", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _text)
+        nothing
+    end
+    function set_text_set(instance::GtkSourceSnippetChunk, _text_set::Bool)
+        ret = ccall(("gtk_source_snippet_chunk_set_text_set", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _text_set)
+        nothing
+    end
+    function set_tooltip_text(instance::GtkSourceSnippetChunk, _tooltip_text::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_snippet_chunk_set_tooltip_text", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _tooltip_text)
+        nothing
+    end
+    function SnippetContext_new()
+        ret = ccall(("gtk_source_snippet_context_new", libgtksourceview), Ptr{GObject}, ())
+        ret2 = GtkSourceSnippetContextLeaf(ret, true)
+        ret2
+    end
+    function clear_variables(instance::GtkSourceSnippetContext)
+        ret = ccall(("gtk_source_snippet_context_clear_variables", libgtksourceview), Nothing, (Ptr{GObject},), instance)
+        nothing
+    end
+    function expand(instance::GtkSourceSnippetContext, _input::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_snippet_context_expand", libgtksourceview), Cstring, (Ptr{GObject}, Cstring), instance, _input)
+        ret2 = string_or_nothing(ret, true)
+        ret2
+    end
+    function get_variable(instance::GtkSourceSnippetContext, _key::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_snippet_context_get_variable", libgtksourceview), Cstring, (Ptr{GObject}, Cstring), instance, _key)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function set_constant(instance::GtkSourceSnippetContext, _key::Union{AbstractString, Symbol}, _value::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_snippet_context_set_constant", libgtksourceview), Nothing, (Ptr{GObject}, Cstring, Cstring), instance, _key, _value)
+        nothing
+    end
+    function set_line_prefix(instance::GtkSourceSnippetContext, _line_prefix::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_snippet_context_set_line_prefix", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _line_prefix)
+        nothing
+    end
+    function set_tab_width(instance::GtkSourceSnippetContext, _tab_width::Integer)
+        ret = ccall(("gtk_source_snippet_context_set_tab_width", libgtksourceview), Nothing, (Ptr{GObject}, Int32), instance, _tab_width)
+        nothing
+    end
+    function set_use_spaces(instance::GtkSourceSnippetContext, _use_spaces::Bool)
+        ret = ccall(("gtk_source_snippet_context_set_use_spaces", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _use_spaces)
+        nothing
+    end
+    function set_variable(instance::GtkSourceSnippetContext, _key::Union{AbstractString, Symbol}, _value::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_snippet_context_set_variable", libgtksourceview), Nothing, (Ptr{GObject}, Cstring, Cstring), instance, _key, _value)
+        nothing
+    end
+    function get_search_path(instance::GtkSourceSnippetManager)
+        ret = ccall(("gtk_source_snippet_manager_get_search_path", libgtksourceview), Ptr{Cstring}, (Ptr{GObject},), instance)
+        ret2 = begin
+                _len = length_zt(ret)
+                arrtemp = bytestring.(unsafe_wrap(Vector{Cstring}, ret, _len))
+                arrtemp
+            end
+        ret2
+    end
+    function get_snippet(instance::GtkSourceSnippetManager, _group::Maybe(Union{AbstractString, Symbol}), _language_id::Maybe(Union{AbstractString, Symbol}), _trigger::Union{AbstractString, Symbol})
+        _group_maybe = nothing_to_null(_group)
+        _language_id_maybe = nothing_to_null(_language_id)
+        ret = ccall(("gtk_source_snippet_manager_get_snippet", libgtksourceview), Ptr{GObject}, (Ptr{GObject}, Cstring, Cstring, Cstring), instance, _group_maybe, _language_id_maybe, _trigger)
+        ret2 = convert_if_not_null(GtkSourceSnippet, ret, true)
+        ret2
+    end
+    function list_all(instance::GtkSourceSnippetManager)
+        ret = ccall(("gtk_source_snippet_manager_list_all", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = begin
+                leaftype = GLib.find_leaf_type(ret)
+                convert(leaftype, ret, false)
+            end
+        ret2
+    end
+    function list_matching(instance::GtkSourceSnippetManager, _group::Maybe(Union{AbstractString, Symbol}), _language_id::Maybe(Union{AbstractString, Symbol}), _trigger_prefix::Maybe(Union{AbstractString, Symbol}))
+        _group_maybe = nothing_to_null(_group)
+        _language_id_maybe = nothing_to_null(_language_id)
+        _trigger_prefix_maybe = nothing_to_null(_trigger_prefix)
+        ret = ccall(("gtk_source_snippet_manager_list_matching", libgtksourceview), Ptr{GObject}, (Ptr{GObject}, Cstring, Cstring, Cstring), instance, _group_maybe, _language_id_maybe, _trigger_prefix_maybe)
+        ret2 = begin
+                leaftype = GLib.find_leaf_type(ret)
+                convert(leaftype, ret, true)
+            end
+        ret2
+    end
+    function set_search_path(instance::GtkSourceSnippetManager, _dirs)
+        _dirs_maybe = nothing_to_null(_dirs)
+        ret = ccall(("gtk_source_snippet_manager_set_search_path", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{Cstring}), instance, _dirs_maybe)
+        nothing
+    end
+    function SpaceDrawer_new()
+        ret = ccall(("gtk_source_space_drawer_new", libgtksourceview), Ptr{GObject}, ())
+        ret2 = GtkSourceSpaceDrawerLeaf(ret, true)
+        ret2
+    end
+    function bind_matrix_setting(instance::GtkSourceSpaceDrawer, _settings::GSettings, _key::Union{AbstractString, Symbol}, _flags)
+        ret = ccall(("gtk_source_space_drawer_bind_matrix_setting", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}, Cstring, UInt32), instance, _settings, _key, _flags)
+        nothing
+    end
+    function get_enable_matrix(instance::GtkSourceSpaceDrawer)
+        ret = ccall(("gtk_source_space_drawer_get_enable_matrix", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_matrix(instance::GtkSourceSpaceDrawer)
+        ret = ccall(("gtk_source_space_drawer_get_matrix", libgtksourceview), Ptr{GVariant}, (Ptr{GObject},), instance)
+        ret2 = convert(GVariant, ret)
+        ret2
+    end
+    function get_types_for_locations(instance::GtkSourceSpaceDrawer, _locations)
+        ret = ccall(("gtk_source_space_drawer_get_types_for_locations", libgtksourceview), UInt32, (Ptr{GObject}, UInt32), instance, _locations)
+        ret2 = SpaceTypeFlags(ret)
+        ret2
+    end
+    function set_enable_matrix(instance::GtkSourceSpaceDrawer, _enable_matrix::Bool)
+        ret = ccall(("gtk_source_space_drawer_set_enable_matrix", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _enable_matrix)
+        nothing
+    end
+    function set_matrix(instance::GtkSourceSpaceDrawer, _matrix::Maybe(GVariant))
+        _matrix_maybe = nothing_to_null(_matrix)
+        ret = ccall(("gtk_source_space_drawer_set_matrix", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GVariant}), instance, _matrix_maybe)
+        nothing
+    end
+    function set_types_for_locations(instance::GtkSourceSpaceDrawer, _locations, _types)
+        ret = ccall(("gtk_source_space_drawer_set_types_for_locations", libgtksourceview), Nothing, (Ptr{GObject}, UInt32, UInt32), instance, _locations, _types)
+        nothing
+    end
+    function apply(instance::GtkSourceStyle, _tag::GtkTextTag)
+        ret = ccall(("gtk_source_style_apply", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _tag)
+        nothing
+    end
+    function copy(instance::GtkSourceStyle)
+        ret = ccall(("gtk_source_style_copy", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceStyle, ret, true)
+        ret2
+    end
+    function get_authors(instance::GtkSourceStyleScheme)
+        ret = ccall(("gtk_source_style_scheme_get_authors", libgtksourceview), Ptr{Cstring}, (Ptr{GObject},), instance)
+        ret2 = begin
+                _len = length_zt(ret)
+                arrtemp = bytestring.(unsafe_wrap(Vector{Cstring}, ret, _len))
+                arrtemp
+            end
+        ret2
+    end
+    function get_description(instance::GtkSourceStyleScheme)
+        ret = ccall(("gtk_source_style_scheme_get_description", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function get_filename(instance::GtkSourceStyleScheme)
+        ret = ccall(("gtk_source_style_scheme_get_filename", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function get_id(instance::GtkSourceStyleScheme)
+        ret = ccall(("gtk_source_style_scheme_get_id", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function get_metadata(instance::GtkSourceStyleScheme, _name::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_style_scheme_get_metadata", libgtksourceview), Cstring, (Ptr{GObject}, Cstring), instance, _name)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function get_name(instance::GtkSourceStyleScheme)
+        ret = ccall(("gtk_source_style_scheme_get_name", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function get_style(instance::GtkSourceStyleScheme, _style_id::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_style_scheme_get_style", libgtksourceview), Ptr{GObject}, (Ptr{GObject}, Cstring), instance, _style_id)
+        ret2 = convert_if_not_null(GtkSourceStyle, ret, false)
+        ret2
+    end
+    function StyleSchemeChooserButton_new()
+        ret = ccall(("gtk_source_style_scheme_chooser_button_new", libgtksourceview), Ptr{GObject}, ())
+        ret2 = GtkSourceStyleSchemeChooserButtonLeaf(ret, false)
+        ret2
+    end
+    function StyleSchemeChooserWidget_new()
+        ret = ccall(("gtk_source_style_scheme_chooser_widget_new", libgtksourceview), Ptr{GObject}, ())
+        ret2 = GtkSourceStyleSchemeChooserWidgetLeaf(ret, false)
+        ret2
+    end
+    function StyleSchemeManager_new()
+        ret = ccall(("gtk_source_style_scheme_manager_new", libgtksourceview), Ptr{GObject}, ())
+        ret2 = GtkSourceStyleSchemeManagerLeaf(ret, true)
+        ret2
+    end
+    function append_search_path(instance::GtkSourceStyleSchemeManager, _path::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_style_scheme_manager_append_search_path", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _path)
+        nothing
+    end
+    function force_rescan(instance::GtkSourceStyleSchemeManager)
+        ret = ccall(("gtk_source_style_scheme_manager_force_rescan", libgtksourceview), Nothing, (Ptr{GObject},), instance)
+        nothing
+    end
+    function get_scheme(instance::GtkSourceStyleSchemeManager, _scheme_id::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_style_scheme_manager_get_scheme", libgtksourceview), Ptr{GObject}, (Ptr{GObject}, Cstring), instance, _scheme_id)
+        ret2 = convert_if_not_null(GtkSourceStyleScheme, ret, false)
+        ret2
+    end
+    function get_scheme_ids(instance::GtkSourceStyleSchemeManager)
+        ret = ccall(("gtk_source_style_scheme_manager_get_scheme_ids", libgtksourceview), Ptr{Cstring}, (Ptr{GObject},), instance)
+        ret2 = begin
+                _len = length_zt(ret)
+                arrtemp = bytestring.(unsafe_wrap(Vector{Cstring}, ret, _len))
+                arrtemp
+            end
+        ret2
+    end
+    function get_search_path(instance::GtkSourceStyleSchemeManager)
+        ret = ccall(("gtk_source_style_scheme_manager_get_search_path", libgtksourceview), Ptr{Cstring}, (Ptr{GObject},), instance)
+        ret2 = begin
+                _len = length_zt(ret)
+                arrtemp = bytestring.(unsafe_wrap(Vector{Cstring}, ret, _len))
+                arrtemp
+            end
+        ret2
+    end
+    function prepend_search_path(instance::GtkSourceStyleSchemeManager, _path::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_style_scheme_manager_prepend_search_path", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _path)
+        nothing
+    end
+    function set_search_path(instance::GtkSourceStyleSchemeManager, _path)
+        _path_maybe = nothing_to_null(_path)
+        ret = ccall(("gtk_source_style_scheme_manager_set_search_path", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{Cstring}), instance, _path_maybe)
+        nothing
+    end
+    function StyleSchemePreview_new(_scheme::GtkSourceStyleScheme)
+        ret = ccall(("gtk_source_style_scheme_preview_new", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), _scheme)
+        ret2 = GtkSourceStyleSchemePreviewLeaf(ret, false)
+        ret2
+    end
+    function get_scheme(instance::GtkSourceStyleSchemePreview)
+        ret = ccall(("gtk_source_style_scheme_preview_get_scheme", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceStyleScheme, ret, false)
+        ret2
+    end
+    function get_selected(instance::GtkSourceStyleSchemePreview)
+        ret = ccall(("gtk_source_style_scheme_preview_get_selected", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function set_selected(instance::GtkSourceStyleSchemePreview, _selected::Bool)
+        ret = ccall(("gtk_source_style_scheme_preview_set_selected", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _selected)
+        nothing
+    end
+    function Tag_new(_name::Maybe(Union{AbstractString, Symbol}))
+        _name_maybe = nothing_to_null(_name)
+        ret = ccall(("gtk_source_tag_new", libgtksourceview), Ptr{GObject}, (Cstring,), _name_maybe)
+        ret2 = GtkSourceTagLeaf(ret, true)
+        ret2
+    end
+    function View_new()
+        ret = ccall(("gtk_source_view_new", libgtksourceview), Ptr{GObject}, ())
+        ret2 = GtkSourceViewLeaf(ret, false)
+        ret2
+    end
+    function View_new_with_buffer(_buffer::GtkSourceBuffer)
+        ret = ccall(("gtk_source_view_new_with_buffer", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), _buffer)
+        ret2 = GtkSourceViewLeaf(ret, false)
+        ret2
+    end
+    function get_auto_indent(instance::GtkSourceView)
+        ret = ccall(("gtk_source_view_get_auto_indent", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_background_pattern(instance::GtkSourceView)
+        ret = ccall(("gtk_source_view_get_background_pattern", libgtksourceview), UInt32, (Ptr{GObject},), instance)
+        ret2 = BackgroundPatternType(ret)
+        ret2
+    end
+    function get_completion(instance::GtkSourceView)
+        ret = ccall(("gtk_source_view_get_completion", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceCompletion, ret, false)
+        ret2
+    end
+    function get_enable_snippets(instance::GtkSourceView)
+        ret = ccall(("gtk_source_view_get_enable_snippets", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_gutter(instance::GtkSourceView, _window_type)
+        ret = ccall(("gtk_source_view_get_gutter", libgtksourceview), Ptr{GObject}, (Ptr{GObject}, UInt32), instance, _window_type)
+        ret2 = convert(GtkSourceGutter, ret, false)
+        ret2
+    end
+    function get_highlight_current_line(instance::GtkSourceView)
+        ret = ccall(("gtk_source_view_get_highlight_current_line", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_hover(instance::GtkSourceView)
+        ret = ccall(("gtk_source_view_get_hover", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceHover, ret, false)
+        ret2
+    end
+    function get_indent_on_tab(instance::GtkSourceView)
+        ret = ccall(("gtk_source_view_get_indent_on_tab", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_indent_width(instance::GtkSourceView)
+        ret = ccall(("gtk_source_view_get_indent_width", libgtksourceview), Int32, (Ptr{GObject},), instance)
+        ret
+    end
+    function get_indenter(instance::GtkSourceView)
+        ret = ccall(("gtk_source_view_get_indenter", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = GLib.find_leaf_type_if_not_null(ret, false)
+        ret2
+    end
+    function get_insert_spaces_instead_of_tabs(instance::GtkSourceView)
+        ret = ccall(("gtk_source_view_get_insert_spaces_instead_of_tabs", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_mark_attributes(instance::GtkSourceView, _category::Union{AbstractString, Symbol}, _priority::Int32)
+        ret = ccall(("gtk_source_view_get_mark_attributes", libgtksourceview), Ptr{GObject}, (Ptr{GObject}, Cstring, Ptr{Int32}), instance, _category, _priority)
+        ret2 = convert(GtkSourceMarkAttributes, ret, false)
+        ret2
+    end
+    function get_right_margin_position(instance::GtkSourceView)
+        ret = ccall(("gtk_source_view_get_right_margin_position", libgtksourceview), UInt32, (Ptr{GObject},), instance)
+        ret
+    end
+    function get_show_line_marks(instance::GtkSourceView)
+        ret = ccall(("gtk_source_view_get_show_line_marks", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_show_line_numbers(instance::GtkSourceView)
+        ret = ccall(("gtk_source_view_get_show_line_numbers", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_show_right_margin(instance::GtkSourceView)
+        ret = ccall(("gtk_source_view_get_show_right_margin", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_smart_backspace(instance::GtkSourceView)
+        ret = ccall(("gtk_source_view_get_smart_backspace", libgtksourceview), Cint, (Ptr{GObject},), instance)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_smart_home_end(instance::GtkSourceView)
+        ret = ccall(("gtk_source_view_get_smart_home_end", libgtksourceview), UInt32, (Ptr{GObject},), instance)
+        ret2 = SmartHomeEndType(ret)
+        ret2
+    end
+    function get_space_drawer(instance::GtkSourceView)
+        ret = ccall(("gtk_source_view_get_space_drawer", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceSpaceDrawer, ret, false)
+        ret2
+    end
+    function get_tab_width(instance::GtkSourceView)
+        ret = ccall(("gtk_source_view_get_tab_width", libgtksourceview), UInt32, (Ptr{GObject},), instance)
+        ret
+    end
+    function get_visual_column(instance::GtkSourceView, _iter::Union{GtkTextIter, Ref{_GtkTextIter}})
+        ret = ccall(("gtk_source_view_get_visual_column", libgtksourceview), UInt32, (Ptr{GObject}, Ptr{_GtkTextIter}), instance, _iter)
+        ret
+    end
+    function indent_lines(instance::GtkSourceView, _start::Union{GtkTextIter, Ref{_GtkTextIter}}, _end::Union{GtkTextIter, Ref{_GtkTextIter}})
+        ret = ccall(("gtk_source_view_indent_lines", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{_GtkTextIter}, Ptr{_GtkTextIter}), instance, _start, _end)
+        nothing
+    end
+    function push_snippet(instance::GtkSourceView, _snippet::GtkSourceSnippet, _location::Maybe(Union{GtkTextIter, Ref{_GtkTextIter}}))
+        _location_maybe = nothing_to_null(_location)
+        ret = ccall(("gtk_source_view_push_snippet", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}, Ptr{_GtkTextIter}), instance, _snippet, _location_maybe)
+        nothing
+    end
+    function set_auto_indent(instance::GtkSourceView, _enable::Bool)
+        ret = ccall(("gtk_source_view_set_auto_indent", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _enable)
+        nothing
+    end
+    function set_background_pattern(instance::GtkSourceView, _background_pattern)
+        ret = ccall(("gtk_source_view_set_background_pattern", libgtksourceview), Nothing, (Ptr{GObject}, UInt32), instance, _background_pattern)
+        nothing
+    end
+    function set_enable_snippets(instance::GtkSourceView, _enable_snippets::Bool)
+        ret = ccall(("gtk_source_view_set_enable_snippets", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _enable_snippets)
+        nothing
+    end
+    function set_highlight_current_line(instance::GtkSourceView, _highlight::Bool)
+        ret = ccall(("gtk_source_view_set_highlight_current_line", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _highlight)
+        nothing
+    end
+    function set_indent_on_tab(instance::GtkSourceView, _enable::Bool)
+        ret = ccall(("gtk_source_view_set_indent_on_tab", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _enable)
+        nothing
+    end
+    function set_indent_width(instance::GtkSourceView, _width::Integer)
+        ret = ccall(("gtk_source_view_set_indent_width", libgtksourceview), Nothing, (Ptr{GObject}, Int32), instance, _width)
+        nothing
+    end
+    function set_indenter(instance::GtkSourceView, _indenter::Maybe(GtkSourceIndenter))
+        _indenter_maybe = nothing_to_null(_indenter)
+        ret = ccall(("gtk_source_view_set_indenter", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _indenter_maybe)
+        nothing
+    end
+    function set_insert_spaces_instead_of_tabs(instance::GtkSourceView, _enable::Bool)
+        ret = ccall(("gtk_source_view_set_insert_spaces_instead_of_tabs", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _enable)
+        nothing
+    end
+    function set_mark_attributes(instance::GtkSourceView, _category::Union{AbstractString, Symbol}, _attributes::GtkSourceMarkAttributes, _priority::Integer)
+        ret = ccall(("gtk_source_view_set_mark_attributes", libgtksourceview), Nothing, (Ptr{GObject}, Cstring, Ptr{GObject}, Int32), instance, _category, _attributes, _priority)
+        nothing
+    end
+    function set_right_margin_position(instance::GtkSourceView, _pos::Integer)
+        ret = ccall(("gtk_source_view_set_right_margin_position", libgtksourceview), Nothing, (Ptr{GObject}, UInt32), instance, _pos)
+        nothing
+    end
+    function set_show_line_marks(instance::GtkSourceView, _show::Bool)
+        ret = ccall(("gtk_source_view_set_show_line_marks", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _show)
+        nothing
+    end
+    function set_show_line_numbers(instance::GtkSourceView, _show::Bool)
+        ret = ccall(("gtk_source_view_set_show_line_numbers", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _show)
+        nothing
+    end
+    function set_show_right_margin(instance::GtkSourceView, _show::Bool)
+        ret = ccall(("gtk_source_view_set_show_right_margin", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _show)
+        nothing
+    end
+    function set_smart_backspace(instance::GtkSourceView, _smart_backspace::Bool)
+        ret = ccall(("gtk_source_view_set_smart_backspace", libgtksourceview), Nothing, (Ptr{GObject}, Cint), instance, _smart_backspace)
+        nothing
+    end
+    function set_smart_home_end(instance::GtkSourceView, _smart_home_end)
+        ret = ccall(("gtk_source_view_set_smart_home_end", libgtksourceview), Nothing, (Ptr{GObject}, UInt32), instance, _smart_home_end)
+        nothing
+    end
+    function set_tab_width(instance::GtkSourceView, _width::Integer)
+        ret = ccall(("gtk_source_view_set_tab_width", libgtksourceview), Nothing, (Ptr{GObject}, UInt32), instance, _width)
+        nothing
+    end
+    function unindent_lines(instance::GtkSourceView, _start::Union{GtkTextIter, Ref{_GtkTextIter}}, _end::Union{GtkTextIter, Ref{_GtkTextIter}})
+        ret = ccall(("gtk_source_view_unindent_lines", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{_GtkTextIter}, Ptr{_GtkTextIter}), instance, _start, _end)
+        nothing
+    end
+    function VimIMContext_new()
+        ret = ccall(("gtk_source_vim_im_context_new", libgtksourceview), Ptr{GObject}, ())
+        ret2 = GtkSourceVimIMContextLeaf(ret, true)
+        ret2
+    end
+    function execute_command(instance::GtkSourceVimIMContext, _command::Union{AbstractString, Symbol})
+        ret = ccall(("gtk_source_vim_im_context_execute_command", libgtksourceview), Nothing, (Ptr{GObject}, Cstring), instance, _command)
+        nothing
+    end
+    function get_command_bar_text(instance::GtkSourceVimIMContext)
+        ret = ccall(("gtk_source_vim_im_context_get_command_bar_text", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function get_command_text(instance::GtkSourceVimIMContext)
+        ret = ccall(("gtk_source_vim_im_context_get_command_text", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, false)
+        ret2
+    end
+    function get_typed_text(instance::GtkSourceCompletionProposal)
+        ret = ccall(("gtk_source_completion_proposal_get_typed_text", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, true)
+        ret2
+    end
+    function activate(instance::GtkSourceCompletionProvider, _context::GtkSourceCompletionContext, _proposal::GtkSourceCompletionProposal)
+        ret = ccall(("gtk_source_completion_provider_activate", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}, Ptr{GObject}), instance, _context, _proposal)
+        nothing
+    end
+    function display(instance::GtkSourceCompletionProvider, _context::GtkSourceCompletionContext, _proposal::GtkSourceCompletionProposal, _cell::GtkSourceCompletionCell)
+        ret = ccall(("gtk_source_completion_provider_display", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}, Ptr{GObject}, Ptr{GObject}), instance, _context, _proposal, _cell)
+        nothing
+    end
+    function get_priority(instance::GtkSourceCompletionProvider, _context::GtkSourceCompletionContext)
+        ret = ccall(("gtk_source_completion_provider_get_priority", libgtksourceview), Int32, (Ptr{GObject}, Ptr{GObject}), instance, _context)
+        ret
+    end
+    function get_title(instance::GtkSourceCompletionProvider)
+        ret = ccall(("gtk_source_completion_provider_get_title", libgtksourceview), Cstring, (Ptr{GObject},), instance)
+        ret2 = string_or_nothing(ret, true)
+        ret2
+    end
+    function is_trigger(instance::GtkSourceCompletionProvider, _iter::Union{GtkTextIter, Ref{_GtkTextIter}}, _ch)
+        ret = ccall(("gtk_source_completion_provider_is_trigger", libgtksourceview), Cint, (Ptr{GObject}, Ptr{_GtkTextIter}, Nothing), instance, _iter, _ch)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function key_activates(instance::GtkSourceCompletionProvider, _context::GtkSourceCompletionContext, _proposal::GtkSourceCompletionProposal, _keyval::Integer, _state)
+        ret = ccall(("gtk_source_completion_provider_key_activates", libgtksourceview), Cint, (Ptr{GObject}, Ptr{GObject}, Ptr{GObject}, UInt32, UInt32), instance, _context, _proposal, _keyval, _state)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function list_alternates(instance::GtkSourceCompletionProvider, _context::GtkSourceCompletionContext, _proposal::GtkSourceCompletionProposal)
+        ret = ccall(("gtk_source_completion_provider_list_alternates", libgtksourceview), Ptr{GPtrArray}, (Ptr{GObject}, Ptr{GObject}, Ptr{GObject}), instance, _context, _proposal)
+        ret
+    end
+    function populate_async(instance::GtkSourceCompletionProvider, _context::GtkSourceCompletionContext, _cancellable::Maybe(GCancellable), _callback::Maybe(Function))
+        _cancellable_maybe = nothing_to_null(_cancellable)
+        if _callback === nothing
+            _callback_cfunc = C_NULL
+            _callback_closure = C_NULL
+        else
+            _callback_cfunc = @cfunction(GAsyncReadyCallback, Nothing, (Ptr{GObject}, Ptr{GObject}, Ref{Function}))
+            _callback_closure = GLib.gc_ref(_callback)
+        end
+        ret = ccall(("gtk_source_completion_provider_populate_async", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}, Ptr{GObject}, Ptr{Cvoid}, Ptr{Nothing}), instance, _context, _cancellable_maybe, _callback_cfunc, _callback_closure)
+        nothing
+    end
+    function populate_finish(instance::GtkSourceCompletionProvider, _result::GAsyncResult)
+        err = err_buf()
+        ret = ccall(("gtk_source_completion_provider_populate_finish", libgtksourceview), Ptr{GObject}, (Ptr{GObject}, Ptr{GObject}, Ptr{Ptr{GError}}), instance, _result, err)
+        check_err(err)
+        ret2 = begin
+                leaftype = GLib.find_leaf_type(ret)
+                convert(leaftype, ret, true)
+            end
+        ret2
+    end
+    function refilter(instance::GtkSourceCompletionProvider, _context::GtkSourceCompletionContext, _model::GListModel)
+        ret = ccall(("gtk_source_completion_provider_refilter", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}, Ptr{GObject}), instance, _context, _model)
+        nothing
+    end
+    function populate_async(instance::GtkSourceHoverProvider, _context::GtkSourceHoverContext, _display::GtkSourceHoverDisplay, _cancellable::Maybe(GCancellable), _callback::Maybe(Function))
+        _cancellable_maybe = nothing_to_null(_cancellable)
+        if _callback === nothing
+            _callback_cfunc = C_NULL
+            _callback_closure = C_NULL
+        else
+            _callback_cfunc = @cfunction(GAsyncReadyCallback, Nothing, (Ptr{GObject}, Ptr{GObject}, Ref{Function}))
+            _callback_closure = GLib.gc_ref(_callback)
+        end
+        ret = ccall(("gtk_source_hover_provider_populate_async", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}, Ptr{GObject}, Ptr{GObject}, Ptr{Cvoid}, Ptr{Nothing}), instance, _context, _display, _cancellable_maybe, _callback_cfunc, _callback_closure)
+        nothing
+    end
+    function populate_finish(instance::GtkSourceHoverProvider, _result::GAsyncResult)
+        err = err_buf()
+        ret = ccall(("gtk_source_hover_provider_populate_finish", libgtksourceview), Cint, (Ptr{GObject}, Ptr{GObject}, Ptr{Ptr{GError}}), instance, _result, err)
+        check_err(err)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function indent(instance::GtkSourceIndenter, _view::GtkSourceView, _iter::Union{GtkTextIter, Ref{_GtkTextIter}})
+        m_iter = Ref{_GtkTextIter}()
+        m_iter[] = Base.cconvert(_GtkTextIter, _iter)
+        ret = ccall(("gtk_source_indenter_indent", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}, Ptr{_GtkTextIter}), instance, _view, m_iter)
+        _iter = m_iter[]
+        _iter
+    end
+    function is_trigger(instance::GtkSourceIndenter, _view::GtkSourceView, _location::Union{GtkTextIter, Ref{_GtkTextIter}}, _state, _keyval::Integer)
+        ret = ccall(("gtk_source_indenter_is_trigger", libgtksourceview), Cint, (Ptr{GObject}, Ptr{GObject}, Ptr{_GtkTextIter}, UInt32, UInt32), instance, _view, _location, _state, _keyval)
+        ret2 = convert(Bool, ret)
+        ret2
+    end
+    function get_style_scheme(instance::GtkSourceStyleSchemeChooser)
+        ret = ccall(("gtk_source_style_scheme_chooser_get_style_scheme", libgtksourceview), Ptr{GObject}, (Ptr{GObject},), instance)
+        ret2 = convert(GtkSourceStyleScheme, ret, false)
+        ret2
+    end
+    function set_style_scheme(instance::GtkSourceStyleSchemeChooser, _scheme::GtkSourceStyleScheme)
+        ret = ccall(("gtk_source_style_scheme_chooser_set_style_scheme", libgtksourceview), Nothing, (Ptr{GObject}, Ptr{GObject}), instance, _scheme)
+        nothing
+    end
+end))
+end

--- a/src/gen/gtksourceview_structs
+++ b/src/gen/gtksourceview_structs
@@ -1,0 +1,1197 @@
+quote
+$(Expr(:toplevel, quote
+    gboxed_types = Any[]
+    struct GtkSourceCompletionProposal <: GInterface
+        handle::Ptr{GObject}
+        gc::Any
+        GtkSourceCompletionProposal(x::GObject) = begin
+                new(unsafe_convert(Ptr{GObject}, x), x)
+            end
+    end
+    struct GtkSourceCompletionProvider <: GInterface
+        handle::Ptr{GObject}
+        gc::Any
+        GtkSourceCompletionProvider(x::GObject) = begin
+                new(unsafe_convert(Ptr{GObject}, x), x)
+            end
+    end
+    struct GtkSourceHoverProvider <: GInterface
+        handle::Ptr{GObject}
+        gc::Any
+        GtkSourceHoverProvider(x::GObject) = begin
+                new(unsafe_convert(Ptr{GObject}, x), x)
+            end
+    end
+    struct GtkSourceIndenter <: GInterface
+        handle::Ptr{GObject}
+        gc::Any
+        GtkSourceIndenter(x::GObject) = begin
+                new(unsafe_convert(Ptr{GObject}, x), x)
+            end
+    end
+    struct GtkSourceStyleSchemeChooser <: GInterface
+        handle::Ptr{GObject}
+        gc::Any
+        GtkSourceStyleSchemeChooser(x::GObject) = begin
+                new(unsafe_convert(Ptr{GObject}, x), x)
+            end
+    end
+    const gtype_wrapper_cache = Dict{Symbol, Type}()
+    begin
+        abstract type GtkSourceBuffer <: GtkTextBuffer end
+        mutable struct GtkSourceBufferLeaf <: GtkSourceBuffer
+            handle::Ptr{GObject}
+            function GtkSourceBufferLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceBufferLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceBuffer] = GtkSourceBufferLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceBuffer) = begin
+                ccall(("gtk_source_buffer_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceBuffer})
+            vcat([:bracket_matched, :cursor_moved, :highlight_updated, :source_mark_updated], signalnames(supertype(GtkSourceBuffer)))
+        end
+        let d = Dict{Symbol, Tuple{Any, Any}}(:notify => (:Nothing, Any[:(Ptr{GParamSpec})]), :undo => (:Nothing, Any[]), :remove_tag => (:Nothing, Any[:(Ptr{GObject}), :_GtkTextIter, :_GtkTextIter]), :insert_child_anchor => (:Nothing, Any[:_GtkTextIter, :(Ptr{GObject})]), :source_mark_updated => (:Nothing, Any[:(Ptr{GObject})]), :cursor_moved => (:Nothing, Any[]), :redo => (:Nothing, Any[]), :begin_user_action => (:Nothing, Any[]), :highlight_updated => (:Nothing, Any[:_GtkTextIter, :_GtkTextIter]), :delete_range => (:Nothing, Any[:_GtkTextIter, :_GtkTextIter]), :bracket_matched => (:Nothing, Any[:_GtkTextIter, :UInt32]), :mark_deleted => (:Nothing, Any[:(Ptr{GObject})]), :end_user_action => (:Nothing, Any[]), :modified_changed => (:Nothing, Any[]), :mark_set => (:Nothing, Any[:_GtkTextIter, :(Ptr{GObject})]), :insert_paintable => (:Nothing, Any[:_GtkTextIter, :(Ptr{GObject})]), :apply_tag => (:Nothing, Any[:(Ptr{GObject}), :_GtkTextIter, :_GtkTextIter]), :changed => (:Nothing, Any[]), :insert_text => (:Nothing, Any[:_GtkTextIter, :Cstring, :Int32]), :paste_done => (:Nothing, Any[:(Ptr{GObject})]))
+            function GLib.signal_return_type(::Type{T}, name::Symbol) where T <: GtkSourceBuffer
+                eval((d[name])[1])
+            end
+            function GLib.signal_argument_types(::Type{T}, name::Symbol) where T <: GtkSourceBuffer
+                Tuple(eval.((d[name])[2]))
+            end
+        end
+    end
+    begin
+        abstract type GtkSourceCompletion <: GObject end
+        mutable struct GtkSourceCompletionLeaf <: GtkSourceCompletion
+            handle::Ptr{GObject}
+            function GtkSourceCompletionLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceCompletionLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceCompletion] = GtkSourceCompletionLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceCompletion) = begin
+                ccall(("gtk_source_completion_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceCompletion})
+            vcat([:hide, :provider_added, :provider_removed, :show], signalnames(supertype(GtkSourceCompletion)))
+        end
+        let d = Dict{Symbol, Tuple{Any, Any}}(:notify => (:Nothing, Any[:(Ptr{GParamSpec})]), :show => (:Nothing, Any[]), :hide => (:Nothing, Any[]), :provider_removed => (:Nothing, Any[:(Ptr{GObject})]), :provider_added => (:Nothing, Any[:(Ptr{GObject})]))
+            function GLib.signal_return_type(::Type{T}, name::Symbol) where T <: GtkSourceCompletion
+                eval((d[name])[1])
+            end
+            function GLib.signal_argument_types(::Type{T}, name::Symbol) where T <: GtkSourceCompletion
+                Tuple(eval.((d[name])[2]))
+            end
+        end
+    end
+    begin
+        abstract type GtkSourceCompletionCell <: GtkWidget end
+        mutable struct GtkSourceCompletionCellLeaf <: GtkSourceCompletionCell
+            handle::Ptr{GObject}
+            function GtkSourceCompletionCellLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceCompletionCellLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceCompletionCell] = GtkSourceCompletionCellLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceCompletionCell) = begin
+                ccall(("gtk_source_completion_cell_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceCompletionCell})
+            signalnames(supertype(GtkSourceCompletionCell))
+        end
+    end
+    begin
+        abstract type GtkSourceCompletionContext <: GObject end
+        mutable struct GtkSourceCompletionContextLeaf <: GtkSourceCompletionContext
+            handle::Ptr{GObject}
+            function GtkSourceCompletionContextLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceCompletionContextLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceCompletionContext] = GtkSourceCompletionContextLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceCompletionContext) = begin
+                ccall(("gtk_source_completion_context_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceCompletionContext})
+            vcat([:provider_model_changed, :items_changed], signalnames(supertype(GtkSourceCompletionContext)))
+        end
+        let d = Dict{Symbol, Tuple{Any, Any}}(:notify => (:Nothing, Any[:(Ptr{GParamSpec})]), :provider_model_changed => (:Nothing, Any[:(Ptr{GObject}), :(Ptr{GObject})]))
+            function GLib.signal_return_type(::Type{T}, name::Symbol) where T <: GtkSourceCompletionContext
+                eval((d[name])[1])
+            end
+            function GLib.signal_argument_types(::Type{T}, name::Symbol) where T <: GtkSourceCompletionContext
+                Tuple(eval.((d[name])[2]))
+            end
+        end
+    end
+    begin
+        abstract type GtkSourceCompletionSnippets <: GObject end
+        mutable struct GtkSourceCompletionSnippetsLeaf <: GtkSourceCompletionSnippets
+            handle::Ptr{GObject}
+            function GtkSourceCompletionSnippetsLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceCompletionSnippetsLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceCompletionSnippets] = GtkSourceCompletionSnippetsLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceCompletionSnippets) = begin
+                ccall(("gtk_source_completion_snippets_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceCompletionSnippets})
+            signalnames(supertype(GtkSourceCompletionSnippets))
+        end
+    end
+    begin
+        abstract type GtkSourceCompletionWords <: GObject end
+        mutable struct GtkSourceCompletionWordsLeaf <: GtkSourceCompletionWords
+            handle::Ptr{GObject}
+            function GtkSourceCompletionWordsLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceCompletionWordsLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceCompletionWords] = GtkSourceCompletionWordsLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceCompletionWords) = begin
+                ccall(("gtk_source_completion_words_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceCompletionWords})
+            signalnames(supertype(GtkSourceCompletionWords))
+        end
+    end
+    begin
+        abstract type GtkSourceFile <: GObject end
+        mutable struct GtkSourceFileLeaf <: GtkSourceFile
+            handle::Ptr{GObject}
+            function GtkSourceFileLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceFileLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceFile] = GtkSourceFileLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceFile) = begin
+                ccall(("gtk_source_file_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceFile})
+            signalnames(supertype(GtkSourceFile))
+        end
+    end
+    begin
+        abstract type GtkSourceFileLoader <: GObject end
+        mutable struct GtkSourceFileLoaderLeaf <: GtkSourceFileLoader
+            handle::Ptr{GObject}
+            function GtkSourceFileLoaderLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceFileLoaderLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceFileLoader] = GtkSourceFileLoaderLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceFileLoader) = begin
+                ccall(("gtk_source_file_loader_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceFileLoader})
+            signalnames(supertype(GtkSourceFileLoader))
+        end
+    end
+    begin
+        abstract type GtkSourceFileSaver <: GObject end
+        mutable struct GtkSourceFileSaverLeaf <: GtkSourceFileSaver
+            handle::Ptr{GObject}
+            function GtkSourceFileSaverLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceFileSaverLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceFileSaver] = GtkSourceFileSaverLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceFileSaver) = begin
+                ccall(("gtk_source_file_saver_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceFileSaver})
+            signalnames(supertype(GtkSourceFileSaver))
+        end
+    end
+    begin
+        abstract type GtkSourceGutter <: GtkWidget end
+        mutable struct GtkSourceGutterLeaf <: GtkSourceGutter
+            handle::Ptr{GObject}
+            function GtkSourceGutterLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceGutterLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceGutter] = GtkSourceGutterLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceGutter) = begin
+                ccall(("gtk_source_gutter_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceGutter})
+            signalnames(supertype(GtkSourceGutter))
+        end
+    end
+    begin
+        abstract type GtkSourceGutterLines <: GObject end
+        mutable struct GtkSourceGutterLinesLeaf <: GtkSourceGutterLines
+            handle::Ptr{GObject}
+            function GtkSourceGutterLinesLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceGutterLinesLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceGutterLines] = GtkSourceGutterLinesLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceGutterLines) = begin
+                ccall(("gtk_source_gutter_lines_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceGutterLines})
+            signalnames(supertype(GtkSourceGutterLines))
+        end
+    end
+    begin
+        abstract type GtkSourceGutterRenderer <: GtkWidget end
+        mutable struct GtkSourceGutterRendererLeaf <: GtkSourceGutterRenderer
+            handle::Ptr{GObject}
+            function GtkSourceGutterRendererLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceGutterRendererLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceGutterRenderer] = GtkSourceGutterRendererLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceGutterRenderer) = begin
+                ccall(("gtk_source_gutter_renderer_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceGutterRenderer})
+            vcat([:activate, :query_activatable, :query_data], signalnames(supertype(GtkSourceGutterRenderer)))
+        end
+        let d = Dict{Symbol, Tuple{Any, Any}}(:notify => (:Nothing, Any[:(Ptr{GParamSpec})]), :state_flags_changed => (:Nothing, Any[:UInt32]), :map => (:Nothing, Any[]), :query_activatable => (:Cint, Any[:_GtkTextIter, :_GdkRectangle]), :unrealize => (:Nothing, Any[]), :show => (:Nothing, Any[]), :unmap => (:Nothing, Any[]), :hide => (:Nothing, Any[]), :query_tooltip => (:Cint, Any[:Int32, :Int32, :Cint, :(Ptr{GObject})]), :query_data => (:Nothing, Any[:(Ptr{GObject}), :UInt32]), :move_focus => (:Nothing, Any[:UInt32]), :mnemonic_activate => (:Cint, Any[:Cint]), :direction_changed => (:Nothing, Any[:UInt32]), :activate => (:Nothing, Any[:_GtkTextIter, :_GdkRectangle, :UInt32, :UInt32, :Int32]), :destroy => (:Nothing, Any[]), :keynav_failed => (:Cint, Any[:UInt32]), :realize => (:Nothing, Any[]))
+            function GLib.signal_return_type(::Type{T}, name::Symbol) where T <: GtkSourceGutterRenderer
+                eval((d[name])[1])
+            end
+            function GLib.signal_argument_types(::Type{T}, name::Symbol) where T <: GtkSourceGutterRenderer
+                Tuple(eval.((d[name])[2]))
+            end
+        end
+    end
+    begin
+        abstract type GtkSourceGutterRendererPixbuf <: GtkSourceGutterRenderer end
+        mutable struct GtkSourceGutterRendererPixbufLeaf <: GtkSourceGutterRendererPixbuf
+            handle::Ptr{GObject}
+            function GtkSourceGutterRendererPixbufLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceGutterRendererPixbufLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceGutterRendererPixbuf] = GtkSourceGutterRendererPixbufLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceGutterRendererPixbuf) = begin
+                ccall(("gtk_source_gutter_renderer_pixbuf_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceGutterRendererPixbuf})
+            signalnames(supertype(GtkSourceGutterRendererPixbuf))
+        end
+    end
+    begin
+        abstract type GtkSourceGutterRendererText <: GtkSourceGutterRenderer end
+        mutable struct GtkSourceGutterRendererTextLeaf <: GtkSourceGutterRendererText
+            handle::Ptr{GObject}
+            function GtkSourceGutterRendererTextLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceGutterRendererTextLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceGutterRendererText] = GtkSourceGutterRendererTextLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceGutterRendererText) = begin
+                ccall(("gtk_source_gutter_renderer_text_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceGutterRendererText})
+            signalnames(supertype(GtkSourceGutterRendererText))
+        end
+    end
+    begin
+        abstract type GtkSourceHover <: GObject end
+        mutable struct GtkSourceHoverLeaf <: GtkSourceHover
+            handle::Ptr{GObject}
+            function GtkSourceHoverLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceHoverLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceHover] = GtkSourceHoverLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceHover) = begin
+                ccall(("gtk_source_hover_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceHover})
+            signalnames(supertype(GtkSourceHover))
+        end
+    end
+    begin
+        abstract type GtkSourceHoverContext <: GObject end
+        mutable struct GtkSourceHoverContextLeaf <: GtkSourceHoverContext
+            handle::Ptr{GObject}
+            function GtkSourceHoverContextLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceHoverContextLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceHoverContext] = GtkSourceHoverContextLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceHoverContext) = begin
+                ccall(("gtk_source_hover_context_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceHoverContext})
+            signalnames(supertype(GtkSourceHoverContext))
+        end
+    end
+    begin
+        abstract type GtkSourceHoverDisplay <: GtkWidget end
+        mutable struct GtkSourceHoverDisplayLeaf <: GtkSourceHoverDisplay
+            handle::Ptr{GObject}
+            function GtkSourceHoverDisplayLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceHoverDisplayLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceHoverDisplay] = GtkSourceHoverDisplayLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceHoverDisplay) = begin
+                ccall(("gtk_source_hover_display_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceHoverDisplay})
+            signalnames(supertype(GtkSourceHoverDisplay))
+        end
+    end
+    begin
+        abstract type GtkSourceLanguage <: GObject end
+        mutable struct GtkSourceLanguageLeaf <: GtkSourceLanguage
+            handle::Ptr{GObject}
+            function GtkSourceLanguageLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceLanguageLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceLanguage] = GtkSourceLanguageLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceLanguage) = begin
+                ccall(("gtk_source_language_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceLanguage})
+            signalnames(supertype(GtkSourceLanguage))
+        end
+    end
+    begin
+        abstract type GtkSourceLanguageManager <: GObject end
+        mutable struct GtkSourceLanguageManagerLeaf <: GtkSourceLanguageManager
+            handle::Ptr{GObject}
+            function GtkSourceLanguageManagerLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceLanguageManagerLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceLanguageManager] = GtkSourceLanguageManagerLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceLanguageManager) = begin
+                ccall(("gtk_source_language_manager_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceLanguageManager})
+            signalnames(supertype(GtkSourceLanguageManager))
+        end
+    end
+    begin
+        abstract type GtkSourceView <: GtkTextView end
+        mutable struct GtkSourceViewLeaf <: GtkSourceView
+            handle::Ptr{GObject}
+            function GtkSourceViewLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceViewLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceView] = GtkSourceViewLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceView) = begin
+                ccall(("gtk_source_view_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceView})
+            vcat([:change_case, :change_number, :join_lines, :line_mark_activated, :move_lines, :move_to_matching_bracket, :move_words, :push_snippet, :show_completion, :smart_home_end], signalnames(supertype(GtkSourceView)))
+        end
+        let d = Dict{Symbol, Tuple{Any, Any}}(:notify => (:Nothing, Any[:(Ptr{GParamSpec})]), :insert_at_cursor => (:Nothing, Any[:Cstring]), :map => (:Nothing, Any[]), :change_case => (:Nothing, Any[:UInt32]), :preedit_changed => (:Nothing, Any[:Cstring]), :line_mark_activated => (:Nothing, Any[:_GtkTextIter, :UInt32, :UInt32, :Int32]), :push_snippet => (:Nothing, Any[:(Ptr{GObject}), :_GtkTextIter]), :move_to_matching_bracket => (:Nothing, Any[:Cint]), :move_words => (:Nothing, Any[:Int32]), :cut_clipboard => (:Nothing, Any[]), :show_completion => (:Nothing, Any[]), :insert_emoji => (:Nothing, Any[]), :toggle_cursor_visible => (:Nothing, Any[]), :smart_home_end => (:Nothing, Any[:_GtkTextIter, :Int32]), :move_focus => (:Nothing, Any[:UInt32]), :direction_changed => (:Nothing, Any[:UInt32]), :join_lines => (:Nothing, Any[]), :state_flags_changed => (:Nothing, Any[:UInt32]), :select_all => (:Nothing, Any[:Cint]), :extend_selection => (:Cint, Any[:UInt32, :_GtkTextIter, :_GtkTextIter, :_GtkTextIter]), :move_lines => (:Nothing, Any[:Cint]), :delete_from_cursor => (:Nothing, Any[:UInt32, :Int32]), :unrealize => (:Nothing, Any[]), :set_anchor => (:Nothing, Any[]), :toggle_overwrite => (:Nothing, Any[]), :backspace => (:Nothing, Any[]), :move_viewport => (:Nothing, Any[:UInt32, :Int32]), :move_cursor => (:Nothing, Any[:UInt32, :Int32, :Cint]), :paste_clipboard => (:Nothing, Any[]), :show => (:Nothing, Any[]), :unmap => (:Nothing, Any[]), :copy_clipboard => (:Nothing, Any[]), :hide => (:Nothing, Any[]), :query_tooltip => (:Cint, Any[:Int32, :Int32, :Cint, :(Ptr{GObject})]), :change_number => (:Nothing, Any[:Int32]), :mnemonic_activate => (:Cint, Any[:Cint]), :destroy => (:Nothing, Any[]), :keynav_failed => (:Cint, Any[:UInt32]), :realize => (:Nothing, Any[]))
+            function GLib.signal_return_type(::Type{T}, name::Symbol) where T <: GtkSourceView
+                eval((d[name])[1])
+            end
+            function GLib.signal_argument_types(::Type{T}, name::Symbol) where T <: GtkSourceView
+                Tuple(eval.((d[name])[2]))
+            end
+        end
+    end
+    begin
+        abstract type GtkSourceMap <: GtkSourceView end
+        mutable struct GtkSourceMapLeaf <: GtkSourceMap
+            handle::Ptr{GObject}
+            function GtkSourceMapLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceMapLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceMap] = GtkSourceMapLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceMap) = begin
+                ccall(("gtk_source_map_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceMap})
+            signalnames(supertype(GtkSourceMap))
+        end
+    end
+    begin
+        abstract type GtkSourceMark <: GtkTextMark end
+        mutable struct GtkSourceMarkLeaf <: GtkSourceMark
+            handle::Ptr{GObject}
+            function GtkSourceMarkLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceMarkLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceMark] = GtkSourceMarkLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceMark) = begin
+                ccall(("gtk_source_mark_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceMark})
+            signalnames(supertype(GtkSourceMark))
+        end
+    end
+    begin
+        abstract type GtkSourceMarkAttributes <: GObject end
+        mutable struct GtkSourceMarkAttributesLeaf <: GtkSourceMarkAttributes
+            handle::Ptr{GObject}
+            function GtkSourceMarkAttributesLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceMarkAttributesLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceMarkAttributes] = GtkSourceMarkAttributesLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceMarkAttributes) = begin
+                ccall(("gtk_source_mark_attributes_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceMarkAttributes})
+            vcat([:query_tooltip_markup, :query_tooltip_text], signalnames(supertype(GtkSourceMarkAttributes)))
+        end
+        let d = Dict{Symbol, Tuple{Any, Any}}(:notify => (:Nothing, Any[:(Ptr{GParamSpec})]), :query_tooltip_markup => (:Cstring, Any[:(Ptr{GObject})]), :query_tooltip_text => (:Cstring, Any[:(Ptr{GObject})]))
+            function GLib.signal_return_type(::Type{T}, name::Symbol) where T <: GtkSourceMarkAttributes
+                eval((d[name])[1])
+            end
+            function GLib.signal_argument_types(::Type{T}, name::Symbol) where T <: GtkSourceMarkAttributes
+                Tuple(eval.((d[name])[2]))
+            end
+        end
+    end
+    begin
+        abstract type GtkSourcePrintCompositor <: GObject end
+        mutable struct GtkSourcePrintCompositorLeaf <: GtkSourcePrintCompositor
+            handle::Ptr{GObject}
+            function GtkSourcePrintCompositorLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourcePrintCompositorLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourcePrintCompositor] = GtkSourcePrintCompositorLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourcePrintCompositor) = begin
+                ccall(("gtk_source_print_compositor_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourcePrintCompositor})
+            signalnames(supertype(GtkSourcePrintCompositor))
+        end
+    end
+    begin
+        abstract type GtkSourceRegion <: GObject end
+        mutable struct GtkSourceRegionLeaf <: GtkSourceRegion
+            handle::Ptr{GObject}
+            function GtkSourceRegionLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceRegionLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceRegion] = GtkSourceRegionLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceRegion) = begin
+                ccall(("gtk_source_region_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceRegion})
+            signalnames(supertype(GtkSourceRegion))
+        end
+    end
+    begin
+        abstract type GtkSourceSearchContext <: GObject end
+        mutable struct GtkSourceSearchContextLeaf <: GtkSourceSearchContext
+            handle::Ptr{GObject}
+            function GtkSourceSearchContextLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceSearchContextLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceSearchContext] = GtkSourceSearchContextLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceSearchContext) = begin
+                ccall(("gtk_source_search_context_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceSearchContext})
+            signalnames(supertype(GtkSourceSearchContext))
+        end
+    end
+    begin
+        abstract type GtkSourceSearchSettings <: GObject end
+        mutable struct GtkSourceSearchSettingsLeaf <: GtkSourceSearchSettings
+            handle::Ptr{GObject}
+            function GtkSourceSearchSettingsLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceSearchSettingsLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceSearchSettings] = GtkSourceSearchSettingsLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceSearchSettings) = begin
+                ccall(("gtk_source_search_settings_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceSearchSettings})
+            signalnames(supertype(GtkSourceSearchSettings))
+        end
+    end
+    begin
+        abstract type GtkSourceSnippet <: GObject end
+        mutable struct GtkSourceSnippetLeaf <: GtkSourceSnippet
+            handle::Ptr{GObject}
+            function GtkSourceSnippetLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceSnippetLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceSnippet] = GtkSourceSnippetLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceSnippet) = begin
+                ccall(("gtk_source_snippet_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceSnippet})
+            signalnames(supertype(GtkSourceSnippet))
+        end
+    end
+    begin
+        abstract type GtkSourceSnippetChunk <: GInitiallyUnowned end
+        mutable struct GtkSourceSnippetChunkLeaf <: GtkSourceSnippetChunk
+            handle::Ptr{GObject}
+            function GtkSourceSnippetChunkLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceSnippetChunkLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceSnippetChunk] = GtkSourceSnippetChunkLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceSnippetChunk) = begin
+                ccall(("gtk_source_snippet_chunk_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceSnippetChunk})
+            signalnames(supertype(GtkSourceSnippetChunk))
+        end
+    end
+    begin
+        abstract type GtkSourceSnippetContext <: GObject end
+        mutable struct GtkSourceSnippetContextLeaf <: GtkSourceSnippetContext
+            handle::Ptr{GObject}
+            function GtkSourceSnippetContextLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceSnippetContextLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceSnippetContext] = GtkSourceSnippetContextLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceSnippetContext) = begin
+                ccall(("gtk_source_snippet_context_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceSnippetContext})
+            vcat([:changed], signalnames(supertype(GtkSourceSnippetContext)))
+        end
+        let d = Dict{Symbol, Tuple{Any, Any}}(:notify => (:Nothing, Any[:(Ptr{GParamSpec})]), :changed => (:Nothing, Any[]))
+            function GLib.signal_return_type(::Type{T}, name::Symbol) where T <: GtkSourceSnippetContext
+                eval((d[name])[1])
+            end
+            function GLib.signal_argument_types(::Type{T}, name::Symbol) where T <: GtkSourceSnippetContext
+                Tuple(eval.((d[name])[2]))
+            end
+        end
+    end
+    begin
+        abstract type GtkSourceSnippetManager <: GObject end
+        mutable struct GtkSourceSnippetManagerLeaf <: GtkSourceSnippetManager
+            handle::Ptr{GObject}
+            function GtkSourceSnippetManagerLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceSnippetManagerLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceSnippetManager] = GtkSourceSnippetManagerLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceSnippetManager) = begin
+                ccall(("gtk_source_snippet_manager_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceSnippetManager})
+            signalnames(supertype(GtkSourceSnippetManager))
+        end
+    end
+    begin
+        abstract type GtkSourceSpaceDrawer <: GObject end
+        mutable struct GtkSourceSpaceDrawerLeaf <: GtkSourceSpaceDrawer
+            handle::Ptr{GObject}
+            function GtkSourceSpaceDrawerLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceSpaceDrawerLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceSpaceDrawer] = GtkSourceSpaceDrawerLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceSpaceDrawer) = begin
+                ccall(("gtk_source_space_drawer_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceSpaceDrawer})
+            signalnames(supertype(GtkSourceSpaceDrawer))
+        end
+    end
+    begin
+        abstract type GtkSourceStyle <: GObject end
+        mutable struct GtkSourceStyleLeaf <: GtkSourceStyle
+            handle::Ptr{GObject}
+            function GtkSourceStyleLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceStyleLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceStyle] = GtkSourceStyleLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceStyle) = begin
+                ccall(("gtk_source_style_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceStyle})
+            signalnames(supertype(GtkSourceStyle))
+        end
+    end
+    begin
+        abstract type GtkSourceStyleScheme <: GObject end
+        mutable struct GtkSourceStyleSchemeLeaf <: GtkSourceStyleScheme
+            handle::Ptr{GObject}
+            function GtkSourceStyleSchemeLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceStyleSchemeLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceStyleScheme] = GtkSourceStyleSchemeLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceStyleScheme) = begin
+                ccall(("gtk_source_style_scheme_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceStyleScheme})
+            signalnames(supertype(GtkSourceStyleScheme))
+        end
+    end
+    begin
+        abstract type GtkSourceStyleSchemeChooserButton <: GtkButton end
+        mutable struct GtkSourceStyleSchemeChooserButtonLeaf <: GtkSourceStyleSchemeChooserButton
+            handle::Ptr{GObject}
+            function GtkSourceStyleSchemeChooserButtonLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceStyleSchemeChooserButtonLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceStyleSchemeChooserButton] = GtkSourceStyleSchemeChooserButtonLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceStyleSchemeChooserButton) = begin
+                ccall(("gtk_source_style_scheme_chooser_button_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceStyleSchemeChooserButton})
+            signalnames(supertype(GtkSourceStyleSchemeChooserButton))
+        end
+    end
+    begin
+        abstract type GtkSourceStyleSchemeChooserWidget <: GtkWidget end
+        mutable struct GtkSourceStyleSchemeChooserWidgetLeaf <: GtkSourceStyleSchemeChooserWidget
+            handle::Ptr{GObject}
+            function GtkSourceStyleSchemeChooserWidgetLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceStyleSchemeChooserWidgetLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceStyleSchemeChooserWidget] = GtkSourceStyleSchemeChooserWidgetLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceStyleSchemeChooserWidget) = begin
+                ccall(("gtk_source_style_scheme_chooser_widget_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceStyleSchemeChooserWidget})
+            signalnames(supertype(GtkSourceStyleSchemeChooserWidget))
+        end
+    end
+    begin
+        abstract type GtkSourceStyleSchemeManager <: GObject end
+        mutable struct GtkSourceStyleSchemeManagerLeaf <: GtkSourceStyleSchemeManager
+            handle::Ptr{GObject}
+            function GtkSourceStyleSchemeManagerLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceStyleSchemeManagerLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceStyleSchemeManager] = GtkSourceStyleSchemeManagerLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceStyleSchemeManager) = begin
+                ccall(("gtk_source_style_scheme_manager_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceStyleSchemeManager})
+            signalnames(supertype(GtkSourceStyleSchemeManager))
+        end
+    end
+    begin
+        abstract type GtkSourceStyleSchemePreview <: GtkWidget end
+        mutable struct GtkSourceStyleSchemePreviewLeaf <: GtkSourceStyleSchemePreview
+            handle::Ptr{GObject}
+            function GtkSourceStyleSchemePreviewLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceStyleSchemePreviewLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceStyleSchemePreview] = GtkSourceStyleSchemePreviewLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceStyleSchemePreview) = begin
+                ccall(("gtk_source_style_scheme_preview_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceStyleSchemePreview})
+            vcat([:activate], signalnames(supertype(GtkSourceStyleSchemePreview)))
+        end
+        let d = Dict{Symbol, Tuple{Any, Any}}(:notify => (:Nothing, Any[:(Ptr{GParamSpec})]), :state_flags_changed => (:Nothing, Any[:UInt32]), :map => (:Nothing, Any[]), :unrealize => (:Nothing, Any[]), :show => (:Nothing, Any[]), :unmap => (:Nothing, Any[]), :hide => (:Nothing, Any[]), :query_tooltip => (:Cint, Any[:Int32, :Int32, :Cint, :(Ptr{GObject})]), :move_focus => (:Nothing, Any[:UInt32]), :mnemonic_activate => (:Cint, Any[:Cint]), :direction_changed => (:Nothing, Any[:UInt32]), :activate => (:Nothing, Any[]), :destroy => (:Nothing, Any[]), :keynav_failed => (:Cint, Any[:UInt32]), :realize => (:Nothing, Any[]))
+            function GLib.signal_return_type(::Type{T}, name::Symbol) where T <: GtkSourceStyleSchemePreview
+                eval((d[name])[1])
+            end
+            function GLib.signal_argument_types(::Type{T}, name::Symbol) where T <: GtkSourceStyleSchemePreview
+                Tuple(eval.((d[name])[2]))
+            end
+        end
+    end
+    begin
+        abstract type GtkSourceTag <: GtkTextTag end
+        mutable struct GtkSourceTagLeaf <: GtkSourceTag
+            handle::Ptr{GObject}
+            function GtkSourceTagLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceTagLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceTag] = GtkSourceTagLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceTag) = begin
+                ccall(("gtk_source_tag_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceTag})
+            signalnames(supertype(GtkSourceTag))
+        end
+    end
+    begin
+        abstract type GtkSourceVimIMContext <: GtkIMContext end
+        mutable struct GtkSourceVimIMContextLeaf <: GtkSourceVimIMContext
+            handle::Ptr{GObject}
+            function GtkSourceVimIMContextLeaf(handle::Ptr{GObject}, owns = false)
+                if handle == C_NULL
+                    error("Cannot construct GtkSourceVimIMContextLeaf with a NULL pointer")
+                end
+                GLib.gobject_maybe_sink(handle, owns)
+                return gobject_ref(new(handle))
+            end
+        end
+        gtype_wrapper_cache[:GtkSourceVimIMContext] = GtkSourceVimIMContextLeaf
+        (GLib.g_type(::Type{T}) where T <: GtkSourceVimIMContext) = begin
+                ccall(("gtk_source_vim_im_context_get_type", libgtksourceview), GType, ())
+            end
+    end
+    begin
+        function GLib.signalnames(::Type{GtkSourceVimIMContext})
+            vcat([:edit, :execute_command, :format_text, :write], signalnames(supertype(GtkSourceVimIMContext)))
+        end
+        let d = Dict{Symbol, Tuple{Any, Any}}(:notify => (:Nothing, Any[:(Ptr{GParamSpec})]), :format_text => (:Nothing, Any[:_GtkTextIter, :_GtkTextIter]), :preedit_changed => (:Nothing, Any[]), :write => (:Nothing, Any[:(Ptr{GObject}), :Cstring]), :preedit_start => (:Nothing, Any[]), :edit => (:Nothing, Any[:(Ptr{GObject}), :Cstring]), :commit => (:Nothing, Any[:Cstring]), :execute_command => (:Cint, Any[:Cstring]), :delete_surrounding => (:Cint, Any[:Int32, :Int32]), :preedit_end => (:Nothing, Any[]), :retrieve_surrounding => (:Cint, Any[]))
+            function GLib.signal_return_type(::Type{T}, name::Symbol) where T <: GtkSourceVimIMContext
+                eval((d[name])[1])
+            end
+            function GLib.signal_argument_types(::Type{T}, name::Symbol) where T <: GtkSourceVimIMContext
+                Tuple(eval.((d[name])[2]))
+            end
+        end
+    end
+    begin
+        gtype_wrapper_cache_init() = begin
+                merge!(GLib.gtype_wrappers, gtype_wrapper_cache)
+            end
+    end
+    function GtkSourceBuffer(_table::Maybe(GtkTextTagTable); kwargs...)
+        obj = G_.Buffer_new(_table)
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceBuffer(_language::GtkSourceLanguage; kwargs...)
+        obj = G_.Buffer_new_with_language(_language)
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceCompletionSnippets(; kwargs...)
+        obj = G_.CompletionSnippets_new()
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceCompletionWords(_title::Maybe(Union{AbstractString, Symbol}); kwargs...)
+        obj = G_.CompletionWords_new(_title)
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceFile(; kwargs...)
+        obj = G_.File_new()
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceFileLoader(_buffer::GtkSourceBuffer, _file::GtkSourceFile; kwargs...)
+        obj = G_.FileLoader_new(_buffer, _file)
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceFileLoader(_buffer::GtkSourceBuffer, _file::GtkSourceFile, _stream::GInputStream; kwargs...)
+        obj = G_.FileLoader_new_from_stream(_buffer, _file, _stream)
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceFileSaver(_buffer::GtkSourceBuffer, _file::GtkSourceFile; kwargs...)
+        obj = G_.FileSaver_new(_buffer, _file)
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceFileSaver(_buffer::GtkSourceBuffer, _file::GtkSourceFile, _target_location::GFile; kwargs...)
+        obj = G_.FileSaver_new_with_target(_buffer, _file, _target_location)
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceGutterRendererPixbuf(; kwargs...)
+        obj = G_.GutterRendererPixbuf_new()
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceGutterRendererText(; kwargs...)
+        obj = G_.GutterRendererText_new()
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceLanguageManager(; kwargs...)
+        obj = G_.LanguageManager_new()
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceMap(; kwargs...)
+        obj = G_.Map_new()
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceMark(_name::Maybe(Union{AbstractString, Symbol}), _category::Union{AbstractString, Symbol}; kwargs...)
+        obj = G_.Mark_new(_name, _category)
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceMarkAttributes(; kwargs...)
+        obj = G_.MarkAttributes_new()
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourcePrintCompositor(_buffer::GtkSourceBuffer; kwargs...)
+        obj = G_.PrintCompositor_new(_buffer)
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourcePrintCompositor(_view::GtkSourceView; kwargs...)
+        obj = G_.PrintCompositor_new_from_view(_view)
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceRegion(_buffer::GtkTextBuffer; kwargs...)
+        obj = G_.Region_new(_buffer)
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceSearchContext(_buffer::GtkSourceBuffer, _settings::Maybe(GtkSourceSearchSettings); kwargs...)
+        obj = G_.SearchContext_new(_buffer, _settings)
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceSearchSettings(; kwargs...)
+        obj = G_.SearchSettings_new()
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceSnippet(_trigger::Maybe(Union{AbstractString, Symbol}), _language_id::Maybe(Union{AbstractString, Symbol}); kwargs...)
+        obj = G_.Snippet_new(_trigger, _language_id)
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceSnippet(_text::Union{AbstractString, Symbol}; kwargs...)
+        obj = G_.Snippet_new_parsed(_text)
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceSnippetChunk(; kwargs...)
+        obj = G_.SnippetChunk_new()
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceSnippetContext()
+        G_.SnippetContext_new()
+    end
+    function GtkSourceSpaceDrawer(; kwargs...)
+        obj = G_.SpaceDrawer_new()
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceStyleSchemeChooserButton()
+        G_.StyleSchemeChooserButton_new()
+    end
+    function GtkSourceStyleSchemeChooserWidget()
+        G_.StyleSchemeChooserWidget_new()
+    end
+    function GtkSourceStyleSchemeManager(; kwargs...)
+        obj = G_.StyleSchemeManager_new()
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceStyleSchemePreview(_scheme::GtkSourceStyleScheme; kwargs...)
+        obj = G_.StyleSchemePreview_new(_scheme)
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceTag(_name::Maybe(Union{AbstractString, Symbol}); kwargs...)
+        obj = G_.Tag_new(_name)
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceView(; kwargs...)
+        obj = G_.View_new()
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceView(_buffer::GtkSourceBuffer; kwargs...)
+        obj = G_.View_new_with_buffer(_buffer)
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    function GtkSourceVimIMContext(; kwargs...)
+        obj = G_.VimIMContext_new()
+        GLib.setproperties!(obj; kwargs...)
+        obj
+    end
+    mutable struct GtkSourceEncoding <: GBoxed
+        handle::Ptr{GtkSourceEncoding}
+        begin
+            (GLib.g_type(::Type{T}) where T <: GtkSourceEncoding) = begin
+                    ccall(("gtk_source_encoding_get_type", libgtksourceview), GType, ())
+                end
+            function GtkSourceEncoding(ref::Ptr{T}, own::Bool = false) where T <: GBoxed
+                x = new(ref)
+                if own
+                    finalizer(x) do x
+                        GLib.delboxed(x)
+                    end
+                end
+                x
+            end
+            push!(gboxed_types, GtkSourceEncoding)
+        end
+    end
+    begin
+        struct _GtkSourceRegionIter
+            dummy1::Ptr{Nothing}
+            dummy2::UInt32
+            dummy3::Ptr{Nothing}
+        end
+        mutable struct GtkSourceRegionIter
+            handle::Ptr{_GtkSourceRegionIter}
+        end
+        unsafe_convert(::Type{Ptr{_GtkSourceRegionIter}}, box::GtkSourceRegionIter) = begin
+                convert(Ptr{_GtkSourceRegionIter}, box.handle)
+            end
+    end
+    gboxed_cache_init() = begin
+            append!(GLib.gboxed_types, gboxed_types)
+        end
+    function GtkSourceSchedulerCallback(deadline, user_data)
+        f = user_data
+        ret = f(deadline)
+        convert(Cint, ret)
+    end
+    export GtkSourceCompletionProposal, GtkSourceCompletionProvider, GtkSourceHoverProvider, GtkSourceIndenter, GtkSourceStyleSchemeChooser, GtkSourceBuffer, GtkSourceBufferLeaf, GtkSourceCompletion, GtkSourceCompletionLeaf, GtkSourceCompletionCell, GtkSourceCompletionCellLeaf, GtkSourceCompletionContext, GtkSourceCompletionContextLeaf, GtkSourceCompletionSnippets, GtkSourceCompletionSnippetsLeaf, GtkSourceCompletionWords, GtkSourceCompletionWordsLeaf, GtkSourceFile, GtkSourceFileLeaf, GtkSourceFileLoader, GtkSourceFileLoaderLeaf, GtkSourceFileSaver, GtkSourceFileSaverLeaf, GtkSourceGutter, GtkSourceGutterLeaf, GtkSourceGutterLines, GtkSourceGutterLinesLeaf, GtkSourceGutterRenderer, GtkSourceGutterRendererPixbuf, GtkSourceGutterRendererPixbufLeaf, GtkSourceGutterRendererText, GtkSourceGutterRendererTextLeaf, GtkSourceHover, GtkSourceHoverLeaf, GtkSourceHoverContext, GtkSourceHoverContextLeaf, GtkSourceHoverDisplay, GtkSourceHoverDisplayLeaf, GtkSourceLanguage, GtkSourceLanguageLeaf, GtkSourceLanguageManager, GtkSourceLanguageManagerLeaf, GtkSourceMap, GtkSourceMapLeaf, GtkSourceMark, GtkSourceMarkLeaf, GtkSourceMarkAttributes, GtkSourceMarkAttributesLeaf, GtkSourcePrintCompositor, GtkSourcePrintCompositorLeaf, GtkSourceRegion, GtkSourceRegionLeaf, GtkSourceSearchContext, GtkSourceSearchContextLeaf, GtkSourceSearchSettings, GtkSourceSearchSettingsLeaf, GtkSourceSnippet, GtkSourceSnippetLeaf, GtkSourceSnippetChunk, GtkSourceSnippetChunkLeaf, GtkSourceSnippetContext, GtkSourceSnippetContextLeaf, GtkSourceSnippetManager, GtkSourceSnippetManagerLeaf, GtkSourceSpaceDrawer, GtkSourceSpaceDrawerLeaf, GtkSourceStyle, GtkSourceStyleLeaf, GtkSourceStyleScheme, GtkSourceStyleSchemeLeaf, GtkSourceStyleSchemeChooserButton, GtkSourceStyleSchemeChooserButtonLeaf, GtkSourceStyleSchemeChooserWidget, GtkSourceStyleSchemeChooserWidgetLeaf, GtkSourceStyleSchemeManager, GtkSourceStyleSchemeManagerLeaf, GtkSourceStyleSchemePreview, GtkSourceStyleSchemePreviewLeaf, GtkSourceTag, GtkSourceTagLeaf, GtkSourceView, GtkSourceViewLeaf, GtkSourceVimIMContext, GtkSourceVimIMContextLeaf, GtkSourceEncoding, GtkSourceRegionIter, _GtkSourceRegionIter, GtkSourceSchedulerCallback
+end))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,32 +1,31 @@
 using GtkSourceWidget, Test
-using Gtk
+using Gtk4
 
 @testset "GtkSourceView" begin
 
     w = GtkWindow()
     b = GtkSourceBuffer()
-    b.text[String] = "test"
+    b.text = "test"
     v = GtkSourceView(b)
     push!(w,v)
-    showall(w)
-    @test b.text[String] == "test"
+    @test b.text == "test"
     
     search_settings = GtkSourceSearchSettings()
     search_context = GtkSourceSearchContext(b, search_settings)
     set_search_text(search_settings, "test")
 
-    it = Gtk.GtkTextIter(b, 1)
+    it = Gtk4._GtkTextIter(b, 1)
     found, its, ite = search_context_forward(search_context, it)
     @test found == true
-    @test (its:ite).text[String] == "test"
+    @test (its:ite).text == "test"
 
     search_context_replace(search_context, its, ite, "it worked!")
     set_search_text(search_settings, "it worked!")
 
-    it = Gtk.GtkTextIter(b, 1)
+    it = Gtk4._GtkTextIter(b, 1)
     found, its, ite = search_context_forward(search_context, it)
     @test found == true
-    @test (its:ite).text[String] == "it worked!"
+    @test (its:ite).text == "it worked!"
 
     mark = create_mark(b, it)
     scroll_to(v, mark, 0, true, 0.5, 0.5)


### PR DESCRIPTION
This gets the tests passing and adds an example. I replaced some of the `ccall`'s with introspected methods, which are in the `G_` submodule. I think we should try to eventually do this with the rest, where possible.

I have not heavily used the text view code in Gtk4. It and the old tree view code were the most painful things to port from Gtk because many of the functions have structs (not pointers to structs) as arguments. In the case of `GtkTextView` the struct passed most often was `GtkTextIter`.

The issue is that in most cases, the `GObject` based libraries use opaque structs, where you don't need to know what the struct members are to use them. All that you deal with is pointers to the structs. So in the introspection generated code, you can call the pointer to one of these `GtkStructName`. For `GtkTextIter`, the struct has members you can access, and the struct gets passed into functions. I think there are many different ways of dealing with this, but the solution I landed on was to call the struct `_GtkTextIter` and the wrapper for the pointer to the struct `GtkTextIter`. So we're going to have to modify code to use this convention. I think there exists a smarter/more elegant solution to this issue, but I haven't needed to deal with a lot of code like this since GTK4 and most of its dependencies moved away from these non-opaque structs (in order to make it easier to create wrappers, I think).